### PR TITLE
Add ability to show code with line numbers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+[*]
+indent_style = tab
+
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function( grunt ) {
 
 			const paths = [
 				'syntax-highlighting-code-block.php',
+				'index.css',
 				'readme.txt',
 				'LICENSE',
 				'build/*',

--- a/index.css
+++ b/index.css
@@ -1,0 +1,25 @@
+.hljs.line-numbers {
+	border-spacing: 0.75em 0;
+	counter-reset: line;
+	display: table;
+}
+
+.hljs.line-numbers .loc {
+	counter-increment: line;
+	display: table-row;
+	width: 100%;
+}
+
+.hljs.line-numbers .loc::before {
+	border-right: 1px solid #ddd;
+	content: counter(line);
+	display: table-cell;
+	padding-right: 0.75em;
+	text-align: right;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	white-space: nowrap;
+	width: 1%;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { sortBy } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { PlainText, InspectorControls } from '@wordpress/editor';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, CheckboxControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -36,11 +36,18 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 			language: {
 				type: 'string',
 			},
+			showLines: {
+				type: 'boolean',
+			},
 		},
 
 		edit( { attributes, setAttributes, className } ) {
 			const updateLanguage = ( language ) => {
 				setAttributes( { language } );
+			};
+
+			const updateShowLines = ( showLines ) => {
+				setAttributes( { showLines } );
 			};
 
 			const sortedLanguageNames = sortBy(
@@ -60,6 +67,11 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 							]
 						}
 						onChange={ updateLanguage }
+					/>
+					<CheckboxControl
+						label={ __( 'Show Line Numbers', 'syntax-highlighting-code-block' ) }
+						checked={ attributes.showLines }
+						onChange={ updateShowLines }
 					/>
 				</InspectorControls>
 				<div key="editor-wrapper" className={ className }>

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -22,8 +22,6 @@ const DEVELOPMENT_MODE = true; // This is automatically rewritten to false durin
 
 const FRONTEND_HIGHLIGHT_STYLE_HANDLE = 'syntax-highlighting-code-block';
 
-const FRONTEND_PLUGIN_STYLE_HANDLE = 'syntax-highlighting-plugin-styles';
-
 /**
  * Get path to script deps file.
  *
@@ -124,13 +122,6 @@ function register_frontend_assets() {
 		[],
 		SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . $default_style_path ) : PLUGIN_VERSION
 	);
-
-	wp_register_style(
-		FRONTEND_PLUGIN_STYLE_HANDLE,
-		plugins_url( 'index.css', __FILE__ ),
-		[],
-		SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . 'index.css' ) : PLUGIN_VERSION
-	);
 }
 
 /**
@@ -160,7 +151,10 @@ function render_block( $attributes, $content ) {
 
 	// Enqueue the style now that we know it will be needed.
 	wp_enqueue_style( FRONTEND_HIGHLIGHT_STYLE_HANDLE );
-	wp_enqueue_style( FRONTEND_PLUGIN_STYLE_HANDLE );
+	wp_add_inline_style(
+		FRONTEND_HIGHLIGHT_STYLE_HANDLE,
+		file_get_contents( plugins_url( 'index.css', __FILE__ ) ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	);
 
 	$inject_classes = function( $start_tags, $language, $show_lines ) {
 		$added_classes = "hljs language-$language";


### PR DESCRIPTION
I haven't developed for WordPress in years, I'm hoping I'm not too far off with this PR.

How do you want to handle line numbers on the front-end?

- Should this plug-in introduce its own CSS dependency to add numbers via pseudo-elements?
- Should it create a table like GitHub?
- Should showing line numbers be a global configuration instead of just a per-block basis?

Closes #11 

Edit: Looks like the build failed. Should `.editorconfig` enforce tabs for indentation? I was hoping my IDE would pick up the correct indentation but it doesn't look like it did.