### PR TITLE
Add theme selector to Customizer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ This plugin extends to Code block in WordPress core to add syntax highlighting w
 
 The extended Code block uses auto-detection for the language in the block to add syntax highlighting, but you can override the language in the block inspector. (There is currently no syntax highlighting of the Code block in the editor.) The plugin supports for all [185 programming languages](https://highlightjs.org/static/demo/) that [highlight.php](https://github.com/scrivo/highlight.php) supports (being a port of [highlight.js](https://highlightjs.org/)).
 
-Any one of [89 styles](https://highlightjs.org/static/demo/) may be enqueued that highlight.php/highlight.js provide. To override the `default` style, use the `syntax_highlighting_code_block_style` to supply the one of the [style names](https://github.com/scrivo/highlight.php/tree/master/styles), for example `github`:
+Any one of [89 styles](https://highlightjs.org/static/demo/) may be enqueued that highlight.php/highlight.js provide. To change the `default` style, you may do so by picking a theme via Customizer in the Colors section. To override the `default` style programmatically, use the `syntax_highlighting_code_block_style` to supply the one of the [style names](https://github.com/scrivo/highlight.php/tree/master/styles), for example `github`:
 
 <pre lang=php>
 add_filter(
@@ -30,6 +30,8 @@ add_filter(
 	}
 );
 </pre>
+
+When a filter is provided, the theme selector in Customizer is automatically disabled.
 
 This plugin is [developed on GitHub](https://github.com/westonruter/syntax-highlighting-code-block). See [list of current issues](https://github.com/westonruter/syntax-highlighting-code-block/issues) with the plugin. Please feel free to file any additional issues or requests that you may come across. [Pull requests](https://github.com/westonruter/syntax-highlighting-code-block/pulls) are welcome to help extend.
 ### Credits ###

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ This plugin extends to Code block in WordPress core to add syntax highlighting w
 
 The extended Code block uses auto-detection for the language in the block to add syntax highlighting, but you can override the language in the block inspector. (There is currently no syntax highlighting of the Code block in the editor.) The plugin supports for all [185 programming languages](https://highlightjs.org/static/demo/) that [highlight.php](https://github.com/scrivo/highlight.php) supports (being a port of [highlight.js](https://highlightjs.org/)).
 
-Any one of [89 styles](https://highlightjs.org/static/demo/) may be enqueued that highlight.php/highlight.js provide. To override the `default` style, use the `syntax_highlighting_code_block_style` to supply the one of the [style names](https://github.com/scrivo/highlight.php/tree/master/styles), for example `github`:
+Any one of [89 styles](https://highlightjs.org/static/demo/) may be enqueued that highlight.php/highlight.js provide. To change the `default` style, you may do so by picking a theme via Customizer in the Colors section. To override the `default` style programmatically, use the `syntax_highlighting_code_block_style` to supply the one of the [style names](https://github.com/scrivo/highlight.php/tree/master/styles), for example `github`:
 
 <pre lang=php>
 add_filter(
@@ -26,6 +26,8 @@ add_filter(
 	}
 );
 </pre>
+
+When a filter is provided, the theme selector in Customizer is automatically disabled.
 
 This plugin is [developed on GitHub](https://github.com/westonruter/syntax-highlighting-code-block). See [list of current issues](https://github.com/westonruter/syntax-highlighting-code-block/issues) with the plugin. Please feel free to file any additional issues or requests that you may come across. [Pull requests](https://github.com/westonruter/syntax-highlighting-code-block/pulls) are welcome to help extend.
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -154,7 +154,7 @@ function register_frontend_assets() {
 
 	$default_style_path = sprintf( 'vendor/scrivo/highlight.php/styles/%s.css', sanitize_key( $style ) );
 	wp_register_style(
-        FRONTEND_STYLE_HANDLE,
+		FRONTEND_STYLE_HANDLE,
 		plugins_url( $default_style_path, __FILE__ ),
 		[],
 		SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . $default_style_path ) : PLUGIN_VERSION
@@ -189,7 +189,7 @@ function render_block( $attributes, $content ) {
 	// Enqueue the style now that we know it will be needed.
 	wp_enqueue_style( FRONTEND_STYLE_HANDLE );
 	wp_add_inline_style(
-        FRONTEND_STYLE_HANDLE,
+		FRONTEND_STYLE_HANDLE,
 		file_get_contents( plugins_url( 'index.css', __FILE__ ) ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	);
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -331,7 +331,8 @@ function customize_register( $wp_customize ) {
 
 	require_once __DIR__ . '/vendor/scrivo/highlight.php/HighlightUtilities/functions.php';
 
-	$themes  = \HighlightUtilities\getAvailableStyleSheets();
+	$themes = \HighlightUtilities\getAvailableStyleSheets();
+	sort( $themes );
 	$choices = array_combine( $themes, $themes );
 
 	$wp_customize->add_setting(

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -297,18 +297,23 @@ function admin_init() {
 add_action( 'admin_init', __NAMESPACE__ . '\admin_init' );
 
 /**
- * Sanitize the given theme name to make sure it's a valid highlight.js theme.
+ * Validate the given stylesheet name against available stylesheets.
  *
- * @param string $input Value of the dropdown.
+ * @param \WP_Error $validity Validator object.
+ * @param string    $input    Incoming theme name.
  *
- * @return string The sanitized theme name
+ * @return mixed
  */
-function sanitize_theme_name( $input ) {
+function validate_theme_name( $validity, $input ) {
 	require_once __DIR__ . '/vendor/scrivo/highlight.php/HighlightUtilities/functions.php';
 
 	$themes = \HighlightUtilities\getAvailableStyleSheets();
 
-	return in_array( $input, $themes, true ) ? sanitize_text_field( $input ) : DEFAULT_THEME;
+	if ( ! in_array( $input, $themes, true ) ) {
+		$validity->add( 'invalid_theme', __( 'Unrecognized theme', 'syntax-highlighting-code-block' ) );
+	}
+
+	return $validity;
 }
 
 /**
@@ -331,7 +336,7 @@ function customize_register( $wp_customize ) {
 		[
 			'type'              => 'option',
 			'default'           => DEFAULT_THEME,
-			'sanitize_callback' => __NAMESPACE__ . '\sanitize_theme_name',
+			'validate_callback' => __NAMESPACE__ . '\validate_theme_name',
 		]
 	);
 	$wp_customize->add_control(

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -144,6 +144,9 @@ function register_frontend_assets() {
 		 * The string returned must correspond to the filenames found at <https://github.com/scrivo/highlight.php/tree/master/styles>,
 		 * minus the file extension.
 		 *
+		 * This filter takes precedence over any settings set in the database as an option. Additionally, if this filter
+		 * is provided, then a theme selector will not be provided in Customizer.
+		 *
 		 * @since 1.0.0
 		 * @param string $style Style.
 		 */


### PR DESCRIPTION
Add a settings page to configure this plug-in. Right now, you can only create a filter to choose the color scheme. This PR gives you a new little dropdown. The filter will still take precedence over this setting.

Closes #10