### PR TITLE
Fix nesting of PanelBody

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { sortBy } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { PlainText, InspectorControls } from '@wordpress/editor';
-import { SelectControl, CheckboxControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
+import { SelectControl, CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -57,33 +57,31 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 
 			return <Fragment>
 				<InspectorControls key="controls">
-					<Panel>
-						<PanelBody
-							title={ __( 'Syntax Highlighting', 'syntax-highlighting-code-block' ) }
-							initialOpen={ true }
-						>
-							<PanelRow>
-								<SelectControl
-									label={ __( 'Language', 'syntax-highlighting-code-block' ) }
-									value={ attributes.language }
-									options={
-										[
-											{ label: __( 'Auto-detect', 'syntax-highlighting-code-block' ), value: '' },
-											...sortedLanguageNames,
-										]
-									}
-									onChange={ updateLanguage }
-								/>
-							</PanelRow>
-							<PanelRow>
-								<CheckboxControl
-									label={ __( 'Show Line Numbers', 'syntax-highlighting-code-block' ) }
-									checked={ attributes.showLines }
-									onChange={ updateShowLines }
-								/>
-							</PanelRow>
-						</PanelBody>
-					</Panel>
+					<PanelBody
+						title={ __( 'Syntax Highlighting', 'syntax-highlighting-code-block' ) }
+						initialOpen={ true }
+					>
+						<PanelRow>
+							<SelectControl
+								label={ __( 'Language', 'syntax-highlighting-code-block' ) }
+								value={ attributes.language }
+								options={
+									[
+										{ label: __( 'Auto-detect', 'syntax-highlighting-code-block' ), value: '' },
+										...sortedLanguageNames,
+									]
+								}
+								onChange={ updateLanguage }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<CheckboxControl
+								label={ __( 'Show Line Numbers', 'syntax-highlighting-code-block' ) }
+								checked={ attributes.showLines }
+								onChange={ updateShowLines }
+							/>
+						</PanelRow>
+					</PanelBody>
 				</InspectorControls>
 				<div key="editor-wrapper" className={ className }>
 					<PlainText


### PR DESCRIPTION
Is declaring a `<Panel>` component inside `<InspectorControls>` necessary? I'm currently seeing this:

**Current:**

![Screen Shot 2019-11-22 at 6 55 46 PM](https://user-images.githubusercontent.com/1246453/69471974-d8df8880-0d59-11ea-9e05-baa81b5a6345.png)

After removing the `<Panel>`, I see something that looks more natural.

**This PR:**

![Screen Shot 2019-11-22 at 6 53 51 PM](https://user-images.githubusercontent.com/1246453/69471977-e09f2d00-0d59-11ea-8fe9-47b57a391693.png)
