### PR TITLE
Add missing HighlightUtilities/functions.php to ZIP

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,7 @@ module.exports = function( grunt ) {
 				'vendor/composer/**',
 				'vendor/scrivo/highlight.php/Highlight/**',
 				'vendor/scrivo/highlight.php/styles/*',
+				'vendor/scrivo/highlight.php/HighlightUtilities/functions.php',
 			];
 
 			grunt.config.set( 'copy', {


### PR DESCRIPTION
Fixes regression introduced in #14, where the `functions.php` from highlight.php was not included in the ZIP for WordPress.org.

Fixes #21.