### PR TITLE
Fix loading script dependencies list

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -150,15 +150,6 @@ function get_option( $option_name ) {
 }
 
 /**
- * Get path to script deps file.
- *
- * @return string Path.
- */
-function get_script_deps_path() {
-	return __DIR__ . '/build/index.deps.json';
-}
-
-/**
  * Require the highlight.php functions file.
  */
 function require_highlight_php_functions() {
@@ -177,7 +168,7 @@ function init() {
 		return;
 	}
 
-	if ( DEVELOPMENT_MODE && ! file_exists( get_script_deps_path() ) ) {
+	if ( DEVELOPMENT_MODE && ! file_exists( __DIR__ . '/build/index.asset.php' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\print_build_required_admin_notice' );
 		return;
 	}
@@ -223,7 +214,7 @@ function enqueue_editor_assets() {
 	$script_path   = '/build/index.js';
 	$style_handle  = 'syntax-highlighting-code-block-styles';
 	$style_path    = '/editor-styles.css';
-	$script_deps   = json_decode( file_get_contents( get_script_deps_path() ), false ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$script_asset  = require __DIR__ . '/build/index.asset.php';
 	$in_footer     = true;
 
 	wp_enqueue_style(
@@ -236,7 +227,7 @@ function enqueue_editor_assets() {
 	wp_enqueue_script(
 		$script_handle,
 		plugins_url( $script_path, __FILE__ ),
-		$script_deps,
+		$script_asset['dependencies'],
 		DEVELOPMENT_MODE ? filemtime( plugin_dir_path( __FILE__ ) . $script_path ) : PLUGIN_VERSION,
 		$in_footer
 	);

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -382,7 +382,7 @@ function render_block( $attributes, $content ) {
 	 */
 	$auto_detect_languages = apply_filters( 'syntax_highlighting_code_block_auto_detect_languages', [] );
 
-	$transient_key = 'syntax-highlighting-code-block-' . md5( wp_json_encode( $attributes ) . implode( '', $auto_detect_languages ) . $matches['content'] ) . '-v' . PLUGIN_VERSION;
+	$transient_key = 'syntax-highlighted-' . md5( wp_json_encode( $attributes ) . implode( '', $auto_detect_languages ) . $matches['content'] . PLUGIN_VERSION );
 	$highlighted   = get_transient( $transient_key );
 
 	if ( ! DEVELOPMENT_MODE && $highlighted && isset( $highlighted['content'] ) ) {

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -191,7 +191,7 @@ function print_build_required_admin_notice() {
 	?>
 	<div class="notice notice-error">
 		<p>
-			<strong><?php esc_html_e( 'Syntax-highlighting Code Block', 'amp' ); ?>:</strong>
+			<strong><?php esc_html_e( 'Syntax-highlighting Code Block', 'syntax-highlighting-code-block' ); ?>:</strong>
 			<?php
 			echo wp_kses_post(
 				sprintf(


### PR DESCRIPTION
With the update to the WordPress packages, the list of dependencies for a given script is now defined in `index.asset.php` rather than `index.deps.json`. This makes that required change.