### PR TITLE
Fix injection of classes in cached block output

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -386,10 +386,7 @@ function render_block( $attributes, $content ) {
 	$highlighted   = get_transient( $transient_key );
 
 	if ( ! DEVELOPMENT_MODE && $highlighted && isset( $highlighted['content'] ) ) {
-		if ( isset( $highlighted['language'] ) ) {
-			$matches['before'] = $inject_classes( $matches['before'], $highlighted['attributes'] );
-		}
-		return $matches['before'] . $highlighted['content'] . $after;
+		return $inject_classes( $matches['before'], $highlighted['attributes'] ) . $highlighted['content'] . $after;
 	}
 
 	try {


### PR DESCRIPTION
I found a bug when testing this on a staging site where `DEVELOPMENT_MODE` is not true. The class names were not getting injected into the container element, resulting in an unexpected result:

> <img width="558" alt="Screen Shot 2020-04-22 at 08 11 48" src="https://user-images.githubusercontent.com/134745/79999916-588c9300-8471-11ea-844b-eda5492de616.png">

The format of the cached data has changed but I didn't update the condition to match. After the change is made here, this is the result:

> <img width="569" alt="Screen Shot 2020-04-22 at 08 12 04" src="https://user-images.githubusercontent.com/134745/80000730-5d057b80-8472-11ea-844d-05ae2dc5e75e.png">
