### PR TITLE
Use mark element to indicate highlighted lines, ensure formatting when styles omitted, add Wrap Lines option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,11 @@
 /* eslint-env node */
 /* eslint-disable camelcase, no-console, no-param-reassign */
 
-module.exports = function( grunt ) {
+module.exports = function (grunt) {
 	'use strict';
 
-	grunt.initConfig( {
-		pkg: grunt.file.readJSON( 'package.json' ),
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
 
 		// Deploys a git Repo to the WordPress SVN repo.
 		wp_deploy: {
@@ -17,32 +17,32 @@ module.exports = function( grunt ) {
 				},
 			},
 		},
-	} );
+	});
 
 	// Load tasks.
-	grunt.loadNpmTasks( 'grunt-contrib-copy' );
-	grunt.loadNpmTasks( 'grunt-wp-deploy' );
+	grunt.loadNpmTasks('grunt-contrib-copy');
+	grunt.loadNpmTasks('grunt-wp-deploy');
 
 	// Register tasks.
-	grunt.registerTask( 'default', [ 'dist' ] );
+	grunt.registerTask('default', ['dist']);
 
-	grunt.registerTask( 'dist', function() {
+	grunt.registerTask('dist', function () {
 		const done = this.async();
 		const spawnQueue = [];
 		const stdout = [];
 
-		spawnQueue.push( {
+		spawnQueue.push({
 			cmd: 'git',
-			args: [ '--no-pager', 'log', '-1', '--format=%h', '--date=short' ],
-		} );
+			args: ['--no-pager', 'log', '-1', '--format=%h', '--date=short'],
+		});
 
 		function finalize() {
 			const commitHash = stdout.shift();
 			const versionAppend =
 				new Date()
 					.toISOString()
-					.replace( /\.\d+/, '' )
-					.replace( /-|:/g, '' ) +
+					.replace(/\.\d+/, '')
+					.replace(/-|:/g, '') +
 				'-' +
 				commitHash;
 
@@ -56,16 +56,16 @@ module.exports = function( grunt ) {
 				'wp-assets/*',
 			];
 
-			grunt.config.set( 'copy', {
+			grunt.config.set('copy', {
 				build: {
 					src: paths,
 					dest: 'dist',
 					expand: true,
 					options: {
-						noProcess: [ '*/**', 'LICENSE' ], // That is, only process syntax-highlighting-code-block.php and readme.txt.
-						process( content, srcpath ) {
+						noProcess: ['*/**', 'LICENSE'], // That is, only process syntax-highlighting-code-block.php and readme.txt.
+						process(content, srcpath) {
 							if (
-								! /syntax-highlighting-code-block\.php$/.test(
+								!/syntax-highlighting-code-block\.php$/.test(
 									srcpath
 								)
 							) {
@@ -76,9 +76,9 @@ module.exports = function( grunt ) {
 							let version;
 
 							// If not a stable build (e.g. 0.7.0-beta), amend the version with the git commit and current timestamp.
-							const matches = content.match( versionRegex );
-							if ( matches ) {
-								version = matches[ 2 ] + '-' + versionAppend;
+							const matches = content.match(versionRegex);
+							if (matches) {
+								version = matches[2] + '-' + versionAppend;
 								console.log(
 									'Updating version in plugin version to ' +
 										version
@@ -103,12 +103,12 @@ module.exports = function( grunt ) {
 					},
 				},
 				composer: {
-					src: [ 'vendor/autoload.php', 'vendor/composer/**' ],
+					src: ['vendor/autoload.php', 'vendor/composer/**'],
 					dest: 'dist',
 					expand: true,
 					options: {
-						noProcess: [ 'vendor/composer/installed.json' ],
-						process( content ) {
+						noProcess: ['vendor/composer/installed.json'],
+						process(content) {
 							return content.replace(
 								/\/highlight\.php/g,
 								'/highlight-php'
@@ -117,36 +117,32 @@ module.exports = function( grunt ) {
 					},
 				},
 				vendor: {
-					src: [
-						'Highlight/**',
-						'HighlightUtilities/**',
-						'styles/*',
-					],
+					src: ['Highlight/**', 'HighlightUtilities/**', 'styles/*'],
 					expand: true,
 					cwd: 'vendor/scrivo/highlight.php/',
 					dest: 'dist/vendor/scrivo/highlight-php/',
 				},
-			} );
-			grunt.task.run( 'copy' );
+			});
+			grunt.task.run('copy');
 
 			done();
 		}
 
 		function doNext() {
 			const nextSpawnArgs = spawnQueue.shift();
-			if ( ! nextSpawnArgs ) {
+			if (!nextSpawnArgs) {
 				finalize();
 			} else {
-				grunt.util.spawn( nextSpawnArgs, function( err, res ) {
-					if ( err ) {
-						throw new Error( err.message );
+				grunt.util.spawn(nextSpawnArgs, function (err, res) {
+					if (err) {
+						throw new Error(err.message);
 					}
-					stdout.push( res.stdout );
+					stdout.push(res.stdout);
 					doNext();
-				} );
+				});
 			}
 		}
 
 		doNext();
-	} );
+	});
 };

--- a/editor-styles.css
+++ b/editor-styles.css
@@ -3,13 +3,23 @@
 }
 
 /* Gutenberg 7.9+ uses a `<code>` element */
-code.shcb-plain-text.shcb-plain-text-wrap-lines {
+code.shcb-plain-text {
 	white-space: pre !important;
+	overflow-x: auto !important;
+}
+
+code.shcb-plain-text.shcb-plain-text-wrap-lines {
+	white-space: pre-wrap !important;
 }
 
 /* Gutenberg 7.8 and below uses a `<textarea>` element */
+textarea.shcb-plain-text {
+	white-space: pre !important;
+	overflow-x: auto !important;
+}
+
 textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
-	white-space: nowrap;
+	white-space: pre-wrap !important;
 }
 
 .code-block-overlay {
@@ -19,9 +29,13 @@ textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
 	pointer-events: none;
 	position: absolute;
 	top: 0;
-	white-space: pre-wrap;
+	white-space: pre;
 	width: 100%;
 	z-index: 10;
+}
+
+.shcb-plain-text-wrap-lines + .code-block-overlay {
+	white-space: pre-wrap;
 }
 
 .code-block-overlay .loc {

--- a/editor-styles.css
+++ b/editor-styles.css
@@ -1,3 +1,17 @@
+.shcb-plain-text.shcb-plain-text-wrap-lines {
+	overflow: auto !important;
+}
+
+/* Gutenberg 7.9+ uses a `<code>` element */
+code.shcb-plain-text.shcb-plain-text-wrap-lines {
+	white-space: pre !important;
+}
+
+/* Gutenberg 7.8 and below uses a `<textarea>` element */
+textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
+	white-space: nowrap;
+}
+
 .code-block-overlay {
 	height: 100%;
 	left: 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4821,6 +4821,12 @@
 					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+					"dev": true
+				},
 				"sprintf-js": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -5130,7 +5136,7 @@
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
 			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 			"dev": true
 		},
@@ -14910,7 +14916,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -16336,9 +16342,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@1.19.1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+			"integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -18517,7 +18523,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -4821,12 +4821,6 @@
 					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@1.19.1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
-					"dev": true
-				},
 				"sprintf-js": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -16339,6 +16333,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prettier": {
+			"version": "npm:wp-prettier@1.19.1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "grunt-wp-deploy": "^2.0.0",
     "highlight.js": "github:highlightjs/highlight.js#9.18.1",
     "lodash": "^4.17.15",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "prettier": "2.0.5"
   },
   "scripts": {
     "update": "bin/update-highlight-libs.sh",

--- a/src/index.js
+++ b/src/index.js
@@ -31,96 +31,94 @@ import languagesNames from './language-names';
  * @param {Object} settings Settings.
  * @return {Object} Modified settings.
  */
-const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
-	if ( 'core/code' !== settings.name ) {
+const extendCodeBlockWithSyntaxHighlighting = (settings) => {
+	if ('core/code' !== settings.name) {
 		return settings;
 	}
 
 	const useLightBlockWrapper =
-		hasBlockSupport( settings, 'core/code', 'lightBlockWrapper', false ) &&
+		hasBlockSupport(settings, 'core/code', 'lightBlockWrapper', false) &&
 		BlockEditor.__experimentalBlock &&
 		BlockEditor.__experimentalBlock.pre;
 
-	const HighlightablePlainText = ( props_ ) => {
+	const HighlightablePlainText = (props_) => {
 		const { highlightedLines, ...props } = props_;
 		const plainTextRef = createRef();
-		const [ styles, setStyles ] = useState( {} );
+		const [styles, setStyles] = useState({});
 
-		useEffect( () => {
-			if ( plainTextRef.current !== null ) {
+		useEffect(() => {
+			if (plainTextRef.current !== null) {
 				let element = plainTextRef.current;
 
 				// In Gutenberg 7.8 and below, the DOM element was stored in a property with the name of the node type.
 				// In 7.9+, the DOM element is now stored in `current`. This block is here for backward-compatibility
 				// with older Gutenberg versions.
-				if ( element.hasOwnProperty( 'textarea' ) ) {
+				if (element.hasOwnProperty('textarea')) {
 					element = plainTextRef.current.textarea;
 				}
 
-				const computedStyles = window.getComputedStyle( element );
+				const computedStyles = window.getComputedStyle(element);
 
-				setStyles( {
-					fontFamily: computedStyles.getPropertyValue(
-						'font-family'
-					),
-					fontSize: computedStyles.getPropertyValue( 'font-size' ),
-					overflow: computedStyles.getPropertyValue( 'overflow' ),
+				setStyles({
+					fontFamily: computedStyles.getPropertyValue('font-family'),
+					fontSize: computedStyles.getPropertyValue('font-size'),
+					overflow: computedStyles.getPropertyValue('overflow'),
 					overflowWrap: computedStyles.getPropertyValue(
 						'overflow-wrap'
 					),
-					resize: computedStyles.getPropertyValue( 'resize' ),
-				} );
+					resize: computedStyles.getPropertyValue('resize'),
+				});
 			}
-		}, [] );
+		}, []);
 
 		return (
 			<Fragment>
-				<PlainText ref={ plainTextRef } { ...props } />
+				<PlainText ref={plainTextRef} {...props} />
 				<div
-					aria-hidden={ true }
+					aria-hidden={true}
 					className="code-block-overlay"
-					style={ styles }
+					style={styles}
 				>
-					{ props.value.split( /\n/ ).map( ( v, i ) => {
+					{props.value.split(/\n/).map((v, i) => {
 						let cName = 'loc';
 
-						if ( highlightedLines.has( i ) ) {
+						if (highlightedLines.has(i)) {
 							cName += ' highlighted';
 						}
 
 						return (
-							<span key={ i } className={ cName }>
-								{ v || ' ' }
+							<span key={i} className={cName}>
+								{v || ' '}
 							</span>
 						);
-					} ) }
+					})}
 				</div>
 			</Fragment>
 		);
 	};
 
-	const parseSelectedLines = ( selectedLines ) => {
+	const parseSelectedLines = (selectedLines) => {
 		const highlightedLines = new Set();
 
-		if ( ! selectedLines || selectedLines.trim().length === 0 ) {
+		if (!selectedLines || selectedLines.trim().length === 0) {
 			return highlightedLines;
 		}
 
 		let chunk;
-		const ranges = selectedLines.replace( /\s/, '' ).split( ',' );
+		const ranges = selectedLines.replace(/\s/, '').split(',');
 
-		for ( chunk of ranges ) {
-			if ( chunk.indexOf( '-' ) >= 0 ) {
+		for (chunk of ranges) {
+			if (chunk.indexOf('-') >= 0) {
 				let i;
-				const range = chunk.split( '-' );
+				const range = chunk.split('-');
 
-				if ( range.length === 2 ) {
-					for ( i = +range[ 0 ]; i <= +range[ 1 ]; ++i ) {
-						highlightedLines.add( i - 1 );
+				if (range.length === 2) {
+					for (i = +range[0]; i <= +range[1]; ++i) {
+						highlightedLines.add(i - 1);
 					}
 				}
 			} else {
-				highlightedLines.add( +chunk - 1 );
+				highlightedLines.add(+chunk - 1);
 			}
 		}
 
@@ -146,118 +144,117 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 			},
 		},
 
-		edit( { attributes, setAttributes, className } ) {
-			const updateLanguage = ( language ) => {
-				setAttributes( { language } );
+		edit({ attributes, setAttributes, className }) {
+			const updateLanguage = (language) => {
+				setAttributes({ language });
 			};
 
-			const updateSelectedLines = ( selectedLines ) => {
-				setAttributes( { selectedLines } );
+			const updateSelectedLines = (selectedLines) => {
+				setAttributes({ selectedLines });
 			};
 
-			const updateShowLines = ( showLines ) => {
-				setAttributes( { showLines } );
+			const updateShowLines = (showLines) => {
+				setAttributes({ showLines });
 			};
 
-			const updateWrapLines = ( wrapLines ) => {
-				setAttributes( { wrapLines } );
+			const updateWrapLines = (wrapLines) => {
+				setAttributes({ wrapLines });
 			};
 
 			const sortedLanguageNames = sortBy(
-				Object.entries(
-					languagesNames
-				).map( ( [ value, label ] ) => ( { label, value } ) ),
-				( languageOption ) => languageOption.label.toLowerCase()
+				Object.entries(languagesNames).map(([value, label]) => ({
+					label,
+					value,
+				})),
+				(languageOption) => languageOption.label.toLowerCase()
 			);
 
 			const plainTextProps = {
 				value: attributes.content || '',
-				highlightedLines: parseSelectedLines(
-					attributes.selectedLines
-				),
-				onChange: ( content ) => setAttributes( { content } ),
-				placeholder: __( 'Write code…' ),
-				'aria-label': __( 'Code' ),
+				highlightedLines: parseSelectedLines(attributes.selectedLines),
+				onChange: (content) => setAttributes({ content }),
+				placeholder: __('Write code…'),
+				'aria-label': __('Code'),
 				className: [
 					'shcb-plain-text',
 					attributes.wrapLines ? 'shcb-plain-text-wrap-lines' : '',
-				].join( ' ' ),
+				].join(' '),
 			};
 
 			return (
 				<Fragment>
 					<InspectorControls key="controls">
 						<PanelBody
-							title={ __( 'Syntax Highlighting' ) }
-							initialOpen={ true }
+							title={__('Syntax Highlighting')}
+							initialOpen={true}
 						>
 							<PanelRow>
 								<SelectControl
-									label={ __( 'Language' ) }
-									value={ attributes.language }
-									options={ [
+									label={__('Language')}
+									value={attributes.language}
+									options={[
 										{
-											label: __( 'Auto-detect' ),
+											label: __('Auto-detect'),
 											value: '',
 										},
 										...sortedLanguageNames,
-									] }
-									onChange={ updateLanguage }
+									]}
+									onChange={updateLanguage}
 								/>
 							</PanelRow>
 							<PanelRow>
 								<TextControl
-									label={ __( 'Highlighted Lines' ) }
-									value={ attributes.selectedLines }
-									onChange={ updateSelectedLines }
-									help={ __( 'Supported format: 1, 3-5' ) }
+									label={__('Highlighted Lines')}
+									value={attributes.selectedLines}
+									onChange={updateSelectedLines}
+									help={__('Supported format: 1, 3-5')}
 								/>
 							</PanelRow>
 							<PanelRow>
 								<CheckboxControl
-									label={ __( 'Show Line Numbers' ) }
-									checked={ attributes.showLines }
-									onChange={ updateShowLines }
+									label={__('Show Line Numbers')}
+									checked={attributes.showLines}
+									onChange={updateShowLines}
 								/>
 							</PanelRow>
 							<PanelRow>
 								<CheckboxControl
-									label={ __( 'Wrap Lines' ) }
-									checked={ attributes.wrapLines }
-									onChange={ updateWrapLines }
+									label={__('Wrap Lines')}
+									checked={attributes.wrapLines}
+									onChange={updateWrapLines}
 								/>
 							</PanelRow>
 						</PanelBody>
 					</InspectorControls>
-					{ useLightBlockWrapper ? (
+					{useLightBlockWrapper ? (
 						// This must be kept in sync with <https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/code/edit.js>.
 						<BlockEditor.__experimentalBlock.pre>
 							<HighlightablePlainText
-								{ ...plainTextProps }
-								__experimentalVersion={ 2 }
+								{...plainTextProps}
+								__experimentalVersion={2}
 								tagName="code"
 							/>
 						</BlockEditor.__experimentalBlock.pre>
 					) : (
-						<div key="editor-wrapper" className={ className }>
-							<HighlightablePlainText { ...plainTextProps } />
+						<div key="editor-wrapper" className={className}>
+							<HighlightablePlainText {...plainTextProps} />
 						</div>
-					) }
+					)}
 				</Fragment>
 			);
 		},
 
-		save( { attributes } ) {
+		save({ attributes }) {
 			return (
 				<pre>
-					<code>{ attributes.content }</code>
+					<code>{attributes.content}</code>
 				</pre>
 			);
 		},
 
 		// Automatically convert core code blocks to this new extended code block.
 		deprecated: [
-			...( settings.deprecated || [] ),
+			...(settings.deprecated || []),
 			{
 				attributes: {
 					...settings.attributes,
@@ -266,17 +263,17 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 					},
 				},
 
-				save( { attributes } ) {
+				save({ attributes }) {
 					const className = attributes.language
 						? 'language-' + attributes.language
 						: '';
 					return (
 						<pre>
 							<code
-								lang={ attributes.language }
-								className={ className }
+								lang={attributes.language}
+								className={className}
 							>
-								{ attributes.content }
+								{attributes.content}
 							</code>
 						</pre>
 					);

--- a/src/index.js
+++ b/src/index.js
@@ -132,15 +132,19 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 			...settings.attributes,
 			language: {
 				type: 'string',
+				default: '',
 			},
 			selectedLines: {
 				type: 'string',
+				default: '',
 			},
 			showLines: {
 				type: 'boolean',
+				default: false,
 			},
 			wrapLines: {
 				type: 'boolean',
+				default: false,
 			},
 		},
 

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,9 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 			showLines: {
 				type: 'boolean',
 			},
+			wrapLines: {
+				type: 'boolean',
+			},
 		},
 
 		edit( { attributes, setAttributes, className } ) {
@@ -154,6 +157,10 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 
 			const updateShowLines = ( showLines ) => {
 				setAttributes( { showLines } );
+			};
+
+			const updateWrapLines = ( wrapLines ) => {
+				setAttributes( { wrapLines } );
 			};
 
 			const sortedLanguageNames = sortBy(
@@ -207,6 +214,13 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 									label={ __( 'Show Line Numbers' ) }
 									checked={ attributes.showLines }
 									onChange={ updateShowLines }
+								/>
+							</PanelRow>
+							<PanelRow>
+								<CheckboxControl
+									label={ __( 'Wrap Lines' ) }
+									checked={ attributes.wrapLines }
+									onChange={ updateWrapLines }
 								/>
 							</PanelRow>
 						</PanelBody>

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ import {
 	PanelRow,
 } from '@wordpress/components';
 import { Fragment, createRef, useEffect, useState } from '@wordpress/element';
-import { hasBlockSupport } from '@wordpress/blocks';
 import * as BlockEditor from '@wordpress/block-editor';
 
 /**
@@ -37,7 +36,8 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 	}
 
 	const useLightBlockWrapper =
-		hasBlockSupport(settings, 'core/code', 'lightBlockWrapper', false) &&
+		settings.supports &&
+		settings.supports.lightBlockWrapper &&
 		BlockEditor.__experimentalBlock &&
 		BlockEditor.__experimentalBlock.pre;
 

--- a/src/index.js
+++ b/src/index.js
@@ -178,10 +178,10 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 				onChange: ( content ) => setAttributes( { content } ),
 				placeholder: __( 'Write code…' ),
 				'aria-label': __( 'Code' ),
-				'className': [
+				className: [
 					'shcb-plain-text',
 					attributes.wrapLines ? 'shcb-plain-text-wrap-lines' : '',
-				].join(' '),
+				].join( ' ' ),
 			};
 
 			return (

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,10 @@ const extendCodeBlockWithSyntaxHighlighting = ( settings ) => {
 				onChange: ( content ) => setAttributes( { content } ),
 				placeholder: __( 'Write code…' ),
 				'aria-label': __( 'Code' ),
+				'className': [
+					'shcb-plain-text',
+					attributes.wrapLines ? 'shcb-plain-text-wrap-lines' : '',
+				].join(' '),
 			};
 
 			return (

--- a/style.css
+++ b/style.css
@@ -17,11 +17,11 @@
 	display: table-cell;
 }
 
-.hljs:not(.shcb-wrap-lines) > .shcb-loc {
+.wp-block-code code.hljs:not(.shcb-wrap-lines) {
 	white-space: pre;
 }
 
-.hljs.shcb-wrap-lines > .shcb-loc {
+.wp-block-code code.hljs.shcb-wrap-lines {
 	white-space: pre-wrap;
 }
 

--- a/style.css
+++ b/style.css
@@ -13,6 +13,10 @@
 	width: 100%;
 }
 
+.hljs.shcb-code-table .shcb-loc > span {
+	display: table-cell;
+}
+
 .hljs.shcb-wrap-lines > .shcb-loc {
 	white-space: pre-wrap;
 }
@@ -27,7 +31,6 @@
 }
 
 .hljs.shcb-line-numbers .shcb-loc > span {
-	display: table-cell;
 	padding-left: 0.75em;
 }
 

--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@
 	display: table-cell;
 }
 
+.hljs:not(.shcb-wrap-lines) > .shcb-loc {
+	white-space: pre;
+}
+
 .hljs.shcb-wrap-lines > .shcb-loc {
 	white-space: pre-wrap;
 }

--- a/style.css
+++ b/style.css
@@ -1,11 +1,20 @@
+.wp-block-code > div {
+	overflow: auto;
+}
+
 .hljs.shcb-code-table {
 	display: table;
 	width: 100%;
 }
 
 .hljs.shcb-code-table > .shcb-loc {
+	color: inherit;
 	display: table-row;
 	width: 100%;
+}
+
+.hljs.shcb-wrap-lines > .shcb-loc {
+	white-space: pre-wrap;
 }
 
 .hljs.shcb-line-numbers {
@@ -18,6 +27,7 @@
 }
 
 .hljs.shcb-line-numbers .shcb-loc > span {
+	display: table-cell;
 	padding-left: 0.75em;
 }
 

--- a/style.css
+++ b/style.css
@@ -1,29 +1,31 @@
-.hljs.line-numbers,
-.hljs.selected-lines {
+.hljs.shcb-code-table {
 	display: table;
 	width: 100%;
 }
 
-.hljs.line-numbers .loc,
-.hljs.selected-lines .loc {
+.hljs.shcb-code-table > .shcb-loc {
 	display: table-row;
 	width: 100%;
 }
 
-.hljs.line-numbers {
+.hljs.shcb-line-numbers {
 	border-spacing: 0;
 	counter-reset: line;
 }
 
-.hljs.line-numbers .loc {
+.hljs.shcb-line-numbers > .shcb-loc {
 	counter-increment: line;
 }
 
-.hljs.line-numbers .loc > span {
+.hljs.shcb-code-table > .shcb-loc > span::after {
+	content: "\200B"; /* Hack to force empty spans to render as table cells */
+}
+
+.hljs.shcb-line-numbers .shcb-loc > span {
 	padding-left: 0.75em;
 }
 
-.hljs.line-numbers .loc::before {
+.hljs.shcb-line-numbers .shcb-loc::before {
 	border-right: 1px solid #ddd;
 	content: counter(line);
 	display: table-cell;

--- a/style.css
+++ b/style.css
@@ -2,6 +2,10 @@
 	overflow: auto;
 }
 
+.hljs {
+	box-sizing: border-box;
+}
+
 .hljs.shcb-code-table {
 	display: table;
 	width: 100%;

--- a/style.css
+++ b/style.css
@@ -17,10 +17,6 @@
 	counter-increment: line;
 }
 
-.hljs.shcb-code-table > .shcb-loc > span::after {
-	content: "\200B"; /* Hack to force empty spans to render as table cells */
-}
-
 .hljs.shcb-line-numbers .shcb-loc > span {
 	padding-left: 0.75em;
 }

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -387,7 +387,7 @@ function render_block( $attributes, $content ) {
 			);
 		}
 
-		return $styles . preg_replace( '/(<pre[^>]*>)(<code)/', '$1<div>$2', $start_tags, 1 );
+		return preg_replace( '/(<pre[^>]*>)(<code)/', '$1<div>$2', $start_tags, 1 );
 	};
 
 	/**
@@ -461,7 +461,7 @@ function render_block( $attributes, $content ) {
 			$attributes
 		);
 
-		return $matches['before'] . $content . $end_tags;
+		return $styles . $matches['before'] . $content . $end_tags;
 	} catch ( Exception $e ) {
 		return sprintf(
 			'<!-- %s(%s): %s -->%s',

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -308,12 +308,18 @@ function render_block( $attributes, $content ) {
 		register_styles( wp_styles() );
 	}
 
+	// Print stylesheet now that we know it will be needed. Note that the stylesheet is not being enqueued at the
+	// wp_enqueue_scripts action because this could result in the stylesheet being printed when it would never be used.
+	// When a stylesheet is printed in the body it has the additional benefit of not being render-blocking. When
+	// a stylesheet is printed the first time, subsequent calls to wp_print_styles() will no-op.
+	ob_start();
+	wp_print_styles( FRONTEND_STYLE_HANDLE );
+	$styles = ob_get_clean();
+
 	// Include line-number styles if requesting to show lines.
 	if ( ! $added_inline_style && ( $attributes['selectedLines'] || $attributes['showLines'] ) ) {
-		wp_add_inline_style(
-			FRONTEND_STYLE_HANDLE,
-			file_get_contents( __DIR__ . '/style.css' ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		);
+		$styles .= sprintf( '<style>%s</style>', file_get_contents( __DIR__ . '/style.css' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents;
+
 		$added_inline_style = true;
 	}
 
@@ -336,17 +342,10 @@ function render_block( $attributes, $content ) {
 
 		$inline_css = ".hljs > mark.shcb-loc { background-color: $line_color; }";
 
-		wp_add_inline_style( FRONTEND_STYLE_HANDLE, $inline_css );
+		$styles .= sprintf( '<style>%s</style>', $inline_css );
+
 		$added_highlighted_color_style = true;
 	}
-
-	// Print stylesheet now that we know it will be needed. Note that the stylesheet is not being enqueued at the
-	// wp_enqueue_scripts action because this could result in the stylesheet being printed when it would never be used.
-	// When a stylesheet is printed in the body it has the additional benefit of not being render-blocking. When
-	// a stylesheet is printed the first time, subsequent calls to wp_print_styles() will no-op.
-	ob_start();
-	wp_print_styles( FRONTEND_STYLE_HANDLE );
-	$styles = ob_get_clean();
 
 	$inject_classes = function( $start_tags, $attributes ) {
 		$added_classes = 'hljs';

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -336,7 +336,7 @@ function render_block( $attributes, $content ) {
 			$line_color = get_option( 'selected_line_bg_color' );
 		}
 
-		$inline_css = ".hljs .loc.highlighted { background-color: $line_color; }";
+		$inline_css = ".hljs > mark.shcb-loc { background-color: $line_color; }";
 
 		wp_add_inline_style( FRONTEND_STYLE_HANDLE, $inline_css );
 		$added_highlighted_color_style = true;
@@ -349,12 +349,16 @@ function render_block( $attributes, $content ) {
 			$added_classes .= " language-{$attributes['language']}";
 		}
 
+		if ( $attributes['showLines'] || $attributes['selectedLines'] ) {
+			$added_classes .= ' shcb-code-table';
+		}
+
 		if ( $attributes['showLines'] ) {
-			$added_classes .= ' line-numbers';
+			$added_classes .= ' shcb-line-numbers';
 		}
 
 		if ( $attributes['selectedLines'] ) {
-			$added_classes .= ' selected-lines';
+			$added_classes .= ' shcb-selected-lines';
 		}
 
 		$start_tags = preg_replace(
@@ -434,19 +438,8 @@ function render_block( $attributes, $content ) {
 			// We need to wrap the line of code twice in order to let out `white-space: pre` CSS setting to be respected
 			// by our `table-row`.
 			foreach ( $lines as $i => $line ) {
-				$class_name = 'loc';
-
-				if ( in_array( $i, $selected_lines, true ) ) {
-					$class_name .= ' highlighted';
-				}
-
-				// Since we're using `display: table-row` in our CSS, empty spans won't render as their own line. So we
-				// need to be explicit about new lines in our spans to render them properly.
-				if ( strlen( $line ) === 0 || preg_match( '#^<span[^>]*></span>$#', $line ) ) {
-					$line = "\n";
-				}
-
-				$content .= sprintf( '<div class="%s"><span>%s</span></div>%s', $class_name, $line, PHP_EOL );
+				$tag_name = in_array( $i, $selected_lines, true ) ? 'mark' : 'span';
+				$content .= "<$tag_name class='shcb-loc'><span>$line</span></$tag_name>\n";
 			}
 		}
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -308,9 +308,6 @@ function render_block( $attributes, $content ) {
 		register_styles( wp_styles() );
 	}
 
-	// Enqueue the style now that we know it will be needed.
-	wp_enqueue_style( FRONTEND_STYLE_HANDLE );
-
 	// Include line-number styles if requesting to show lines.
 	if ( ! $added_inline_style && ( $attributes['selectedLines'] || $attributes['showLines'] ) ) {
 		wp_add_inline_style(
@@ -342,6 +339,12 @@ function render_block( $attributes, $content ) {
 		wp_add_inline_style( FRONTEND_STYLE_HANDLE, $inline_css );
 		$added_highlighted_color_style = true;
 	}
+
+	// Print stylesheet now that we know it will be needed. Note that the stylesheet is not being enqueued at the
+	// wp_enqueue_scripts action because this could result in the stylesheet being printed when it would never be used.
+	// When a stylesheet is printed in the body it has the additional benefit of not being render-blocking. When
+	// a stylesheet is printed the first time, subsequent calls to wp_print_styles() will no-op.
+	wp_print_styles( FRONTEND_STYLE_HANDLE );
 
 	$inject_classes = function( $start_tags, $attributes ) {
 		$added_classes = 'hljs';

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -228,7 +228,7 @@ function enqueue_editor_assets() {
 		$script_handle,
 		plugins_url( $script_path, __FILE__ ),
 		$script_asset['dependencies'],
-		DEVELOPMENT_MODE ? filemtime( plugin_dir_path( __FILE__ ) . $script_path ) : PLUGIN_VERSION,
+		$script_asset['version'],
 		$in_footer
 	);
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -344,7 +344,9 @@ function render_block( $attributes, $content ) {
 	// wp_enqueue_scripts action because this could result in the stylesheet being printed when it would never be used.
 	// When a stylesheet is printed in the body it has the additional benefit of not being render-blocking. When
 	// a stylesheet is printed the first time, subsequent calls to wp_print_styles() will no-op.
+	ob_start();
 	wp_print_styles( FRONTEND_STYLE_HANDLE );
+	$styles = ob_get_clean();
 
 	$inject_classes = function( $start_tags, $attributes ) {
 		$added_classes = 'hljs';
@@ -385,7 +387,7 @@ function render_block( $attributes, $content ) {
 			);
 		}
 
-		return preg_replace( '/(<pre[^>]*>)(<code)/', '$1<div>$2', $start_tags, 1 );
+		return $styles . preg_replace( '/(<pre[^>]*>)(<code)/', '$1<div>$2', $start_tags, 1 );
 	};
 
 	/**

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -318,7 +318,7 @@ function render_block( $attributes, $content ) {
 
 	// Include line-number styles if requesting to show lines.
 	if ( ! $added_inline_style && ( $attributes['selectedLines'] || $attributes['showLines'] ) ) {
-		$styles .= sprintf( '<style>%s</style>', file_get_contents( __DIR__ . '/style.css' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents;
+		$styles .= sprintf( '<style>%s</style>', file_get_contents( __DIR__ . '/style.css' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 		$added_inline_style = true;
 	}

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -439,7 +439,7 @@ function render_block( $attributes, $content ) {
 			// by our `table-row`.
 			foreach ( $lines as $i => $line ) {
 				$tag_name = in_array( $i, $selected_lines, true ) ? 'mark' : 'span';
-				$content .= "<$tag_name class='shcb-loc'><span>$line</span></$tag_name>\n";
+				$content .= "<$tag_name class='shcb-loc'><span>$line\n</span></$tag_name>";
 			}
 		}
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -298,9 +298,9 @@ function render_block( $attributes, $content ) {
 		$attributes,
 		[
 			'language'      => '',
-			'showLines'     => '',
 			'selectedLines' => '',
-			'wrapLines'     => '',
+			'showLines'     => false,
+			'wrapLines'     => false,
 		]
 	);
 


### PR DESCRIPTION
Fixes #79.
Fixes #78.

* Use `mark` element to indicate highlighted lines.
* Use CSS hack to force empty cell to show instead of line break.
* Prefix class names.
* Ensure Code block renders properly when no styles are loaded.
* Prevent flash of unstyled content by printing stylesheet before first Code block.
* Add Wrap Lines option, and ensure do not wrap by default for consistency.
* Improve code style.

With styles (note the lack of highlights and extra line breaks):

> ![image](https://user-images.githubusercontent.com/134745/80041867-68789700-84b2-11ea-8f04-8f9bb6dfee01.png)

Before without styles:

> ![image](https://user-images.githubusercontent.com/134745/80041935-98c03580-84b2-11ea-9828-a0a360050b67.png)

After without styles (with line spacing and highlights preserved):

> ![image](https://user-images.githubusercontent.com/134745/80042054-e046c180-84b2-11ea-995a-bb0d9728914c.png)

Note this is in the Twenty Twenty theme which has a default style of:

```css
mark {
	background-color: #eee;
	color: #222;
}
```