### PR TITLE
Ensure proper text domain is passed to translation functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,18 @@
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
 [*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = tab
 
+[{.babelrc,.eslintrc,.rtlcssrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
 [*.md]
-max_line_length = off
 trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "extends": [
-    "plugin:@wordpress/eslint-plugin/recommended",
+    "plugin:@wordpress/eslint-plugin/recommended"
   ],
   "settings": {
     "react": {
@@ -11,5 +11,13 @@
   },
   "globals": {
     "browser": true
+  },
+  "rules": {
+    "@wordpress/i18n-text-domain": [
+      "error",
+      {
+        "allowedTextDomain": [ "syntax-highlighting-code-block", "default" ]
+      }
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -189,16 +189,25 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 				<Fragment>
 					<InspectorControls key="controls">
 						<PanelBody
-							title={__('Syntax Highlighting')}
+							title={__(
+								'Syntax Highlighting',
+								'syntax-highlighting-code-block'
+							)}
 							initialOpen={true}
 						>
 							<PanelRow>
 								<SelectControl
-									label={__('Language')}
+									label={__(
+										'Language',
+										'syntax-highlighting-code-block'
+									)}
 									value={attributes.language}
 									options={[
 										{
-											label: __('Auto-detect'),
+											label: __(
+												'Auto-detect',
+												'syntax-highlighting-code-block'
+											),
 											value: '',
 										},
 										...sortedLanguageNames,
@@ -208,22 +217,34 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 							</PanelRow>
 							<PanelRow>
 								<TextControl
-									label={__('Highlighted Lines')}
+									label={__(
+										'Highlighted Lines',
+										'syntax-highlighting-code-block'
+									)}
 									value={attributes.selectedLines}
 									onChange={updateSelectedLines}
-									help={__('Supported format: 1, 3-5')}
+									help={__(
+										'Supported format: 1, 3-5',
+										'syntax-highlighting-code-block'
+									)}
 								/>
 							</PanelRow>
 							<PanelRow>
 								<CheckboxControl
-									label={__('Show Line Numbers')}
+									label={__(
+										'Show Line Numbers',
+										'syntax-highlighting-code-block'
+									)}
 									checked={attributes.showLines}
 									onChange={updateShowLines}
 								/>
 							</PanelRow>
 							<PanelRow>
 								<CheckboxControl
-									label={__('Wrap Lines')}
+									label={__(
+										'Wrap Lines',
+										'syntax-highlighting-code-block'
+									)}
 									checked={attributes.wrapLines}
 									onChange={updateWrapLines}
 								/>


### PR DESCRIPTION
Cheers to @swissspidy for his advice on how to configure the eslint rule.