### PR TITLE
Remove padding from Code blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
 .wp-block-code {
+	border: 0;
 	padding: 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+.wp-block-code {
+	padding: 0;
+}
+
 .wp-block-code > div {
 	overflow: auto;
 }

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -317,7 +317,7 @@ function render_block( $attributes, $content ) {
 	$styles = ob_get_clean();
 
 	// Include line-number styles if requesting to show lines.
-	if ( ! $added_inline_style && ( $attributes['selectedLines'] || $attributes['showLines'] ) ) {
+	if ( ! $added_inline_style ) {
 		$styles .= sprintf( '<style>%s</style>', file_get_contents( __DIR__ . '/style.css' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 		$added_inline_style = true;
@@ -340,9 +340,7 @@ function render_block( $attributes, $content ) {
 			$line_color = get_option( 'selected_line_bg_color' );
 		}
 
-		$inline_css = ".hljs > mark.shcb-loc { background-color: $line_color; }";
-
-		$styles .= sprintf( '<style>%s</style>', $inline_css );
+		$styles .= "<style>.hljs > mark.shcb-loc { background-color: $line_color; }</style>";
 
 		$added_highlighted_color_style = true;
 	}


### PR DESCRIPTION
I realized there was some undesirable padding in Twenty Twenty and Twenty Nineteen being applied to the `.wp-block-code` element. Themes made before this (e.g. Twenty Seventeen) don't have this issue because the block editor debuted with Twenty Nineteen.

## Twenty Twenty

Before | After
-------|-------
![image](https://user-images.githubusercontent.com/134745/80317927-77658f00-87bb-11ea-8aab-69e2ed807b55.png) | ![image](https://user-images.githubusercontent.com/134745/80317935-81878d80-87bb-11ea-941f-3f9e67c1577e.png)

## Twenty Nineteen

Before | After
-------|-------
![image](https://user-images.githubusercontent.com/134745/80317962-b8f63a00-87bb-11ea-99e3-50d9b2cfae45.png) | ![image](https://user-images.githubusercontent.com/134745/80317966-c4e1fc00-87bb-11ea-81fe-8ea46a27f639.png)


