### PR TITLE
Define attribute schema in PHP with registered block type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* global syntaxHighlightingCodeBlockType */
+
 /**
  * External dependencies
  */
@@ -31,7 +33,7 @@ import languagesNames from './language-names';
  * @return {Object} Modified settings.
  */
 const extendCodeBlockWithSyntaxHighlighting = (settings) => {
-	if ('core/code' !== settings.name) {
+	if (syntaxHighlightingCodeBlockType.name !== settings.name) {
 		return settings;
 	}
 
@@ -128,24 +130,14 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 	return {
 		...settings,
 
+		/*
+		 * @todo Why do the attributes need to be augmented here when they have already been declared for the block type in PHP?
+		 * There seems to be a race condition, as wp.blocks.getBlockType('core/code') returns the PHP-augmented data after the
+		 * page loads, but at the moment this filter calls it is still undefined.
+		 */
 		attributes: {
 			...settings.attributes,
-			language: {
-				type: 'string',
-				default: '',
-			},
-			selectedLines: {
-				type: 'string',
-				default: '',
-			},
-			showLines: {
-				type: 'boolean',
-				default: false,
-			},
-			wrapLines: {
-				type: 'boolean',
-				default: false,
-			},
+			...syntaxHighlightingCodeBlockType.attributes, // @todo Why can't this be supplied via a blocks.getBlockAttributes filter?
 		},
 
 		edit({ attributes, setAttributes, className }) {
@@ -262,9 +254,7 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 			{
 				attributes: {
 					...settings.attributes,
-					language: {
-						type: 'string',
-					},
+					...syntaxHighlightingCodeBlockType.attributes, // @todo Is this needed?
 				},
 
 				save({ attributes }) {
@@ -289,6 +279,6 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 
 addFilter(
 	'blocks.registerBlockType',
-	'westonruter/syntax-highlighting-code-block',
+	'westonruter/syntax-highlighting-code-block-type',
 	extendCodeBlockWithSyntaxHighlighting
 );

--- a/src/index.js
+++ b/src/index.js
@@ -247,33 +247,6 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 				</pre>
 			);
 		},
-
-		// Automatically convert core code blocks to this new extended code block.
-		deprecated: [
-			...(settings.deprecated || []),
-			{
-				attributes: {
-					...settings.attributes,
-					...syntaxHighlightingCodeBlockType.attributes, // @todo Is this needed?
-				},
-
-				save({ attributes }) {
-					const className = attributes.language
-						? 'language-' + attributes.language
-						: '';
-					return (
-						<pre>
-							<code
-								lang={attributes.language}
-								className={className}
-							>
-								{attributes.content}
-							</code>
-						</pre>
-					);
-				},
-			},
-		],
 	};
 };
 


### PR DESCRIPTION
This PR defines the block attributes centrally in PHP. This allows for plugins to easily change the default values for a block's attributes. For example, if a site wants all blocks to have wrapped lines and have PHP selected by default, they can do so with this code:

```php
add_action( 'init', function() {
	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/code' );
	$block_type->attributes['language']['default'] = 'php';
	$block_type->attributes['wrapLines']['default'] = true;
} );
```

The great thing about this is that the defaults will be reflected in the editor and for every instance of the generic Code block already created when rendered on the frontend.

This PR also removes obsolete deprecated block definition which is now only relevant in mkaz/code-syntax-block.