### PR TITLE
Rename attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,15 +99,15 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 		);
 	};
 
-	const parseSelectedLines = (selectedLines) => {
-		const highlightedLines = new Set();
+	const parseSelectedLines = (highlightedLines) => {
+		const highlightedLinesSet = new Set();
 
-		if (!selectedLines || selectedLines.trim().length === 0) {
-			return highlightedLines;
+		if (!highlightedLines || highlightedLines.trim().length === 0) {
+			return highlightedLinesSet;
 		}
 
 		let chunk;
-		const ranges = selectedLines.replace(/\s/, '').split(',');
+		const ranges = highlightedLines.replace(/\s/, '').split(',');
 
 		for (chunk of ranges) {
 			if (chunk.indexOf('-') >= 0) {
@@ -116,15 +116,15 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 
 				if (range.length === 2) {
 					for (i = +range[0]; i <= +range[1]; ++i) {
-						highlightedLines.add(i - 1);
+						highlightedLinesSet.add(i - 1);
 					}
 				}
 			} else {
-				highlightedLines.add(+chunk - 1);
+				highlightedLinesSet.add(+chunk - 1);
 			}
 		}
 
-		return highlightedLines;
+		return highlightedLinesSet;
 	};
 
 	return {
@@ -145,12 +145,12 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 				setAttributes({ language });
 			};
 
-			const updateSelectedLines = (selectedLines) => {
-				setAttributes({ selectedLines });
+			const updateHighlightedLines = (highlightedLines) => {
+				setAttributes({ highlightedLines });
 			};
 
-			const updateShowLines = (showLines) => {
-				setAttributes({ showLines });
+			const updateShowLineNumbers = (showLineNumbers) => {
+				setAttributes({ showLineNumbers });
 			};
 
 			const updateWrapLines = (wrapLines) => {
@@ -167,7 +167,9 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 
 			const plainTextProps = {
 				value: attributes.content || '',
-				highlightedLines: parseSelectedLines(attributes.selectedLines),
+				highlightedLines: parseSelectedLines(
+					attributes.highlightedLines
+				),
 				onChange: (content) => setAttributes({ content }),
 				placeholder: __('Write code…'),
 				'aria-label': __('Code'),
@@ -213,8 +215,8 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 										'Highlighted Lines',
 										'syntax-highlighting-code-block'
 									)}
-									value={attributes.selectedLines}
-									onChange={updateSelectedLines}
+									value={attributes.highlightedLines}
+									onChange={updateHighlightedLines}
 									help={__(
 										'Supported format: 1, 3-5',
 										'syntax-highlighting-code-block'
@@ -227,8 +229,8 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 										'Show Line Numbers',
 										'syntax-highlighting-code-block'
 									)}
-									checked={attributes.showLines}
-									onChange={updateShowLines}
+									checked={attributes.showLineNumbers}
+									onChange={updateShowLineNumbers}
 								/>
 							</PanelRow>
 							<PanelRow>

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -181,19 +181,19 @@ function init() {
 		[
 			'render_callback' => __NAMESPACE__ . '\render_block',
 			'attributes'      => [
-				'language'      => [
+				'language'         => [
 					'type'    => 'string',
 					'default' => '',
 				],
-				'selectedLines' => [
+				'highlightedLines' => [
 					'type'    => 'string',
 					'default' => '',
 				],
-				'showLines'     => [
+				'showLineNumbers'  => [
 					'type'    => 'boolean',
 					'default' => false,
 				],
-				'wrapLines'     => [
+				'wrapLines'        => [
 					'type'    => 'boolean',
 					'default' => false,
 				],
@@ -317,6 +317,16 @@ function render_block( $attributes, $content ) {
 	static $added_inline_style            = false;
 	static $added_highlighted_color_style = false;
 
+	// Migrate legacy attribute names.
+	if ( isset( $attributes['selectedLines'] ) ) {
+		$attributes['highlightedLines'] = $attributes['selectedLines'];
+		unset( $attributes['selectedLines'] );
+	}
+	if ( isset( $attributes['showLines'] ) ) {
+		$attributes['showLineNumbers'] = $attributes['showLines'];
+		unset( $attributes['showLines'] );
+	}
+
 	$pattern  = '(?P<before><pre.*?><code.*?>)';
 	$pattern .= '(?P<content>.*)';
 	$pattern .= '</code></pre>';
@@ -346,7 +356,7 @@ function render_block( $attributes, $content ) {
 		$added_inline_style = true;
 	}
 
-	if ( ! $added_highlighted_color_style && $attributes['selectedLines'] ) {
+	if ( ! $added_highlighted_color_style && $attributes['highlightedLines'] ) {
 		if ( has_filter( SELECTED_LINE_BG_FILTER ) ) {
 			/**
 			 * Filters the background color of a selected line.
@@ -375,15 +385,15 @@ function render_block( $attributes, $content ) {
 			$added_classes .= " language-{$attributes['language']}";
 		}
 
-		if ( $attributes['showLines'] || $attributes['selectedLines'] ) {
+		if ( $attributes['showLineNumbers'] || $attributes['highlightedLines'] ) {
 			$added_classes .= ' shcb-code-table';
 		}
 
-		if ( $attributes['showLines'] ) {
+		if ( $attributes['showLineNumbers'] ) {
 			$added_classes .= ' shcb-line-numbers';
 		}
 
-		if ( $attributes['selectedLines'] ) {
+		if ( $attributes['highlightedLines'] ) {
 			$added_classes .= ' shcb-selected-lines';
 		}
 
@@ -459,10 +469,10 @@ function render_block( $attributes, $content ) {
 		$attributes['language'] = $r->language;
 
 		$content = $r->value;
-		if ( $attributes['showLines'] || $attributes['selectedLines'] ) {
+		if ( $attributes['showLineNumbers'] || $attributes['highlightedLines'] ) {
 			require_highlight_php_functions();
 
-			$selected_lines = parse_selected_lines( $attributes['selectedLines'] );
+			$selected_lines = parse_selected_lines( $attributes['highlightedLines'] );
 			$lines          = \HighlightUtilities\splitCodeIntoArray( $content );
 			$content        = '';
 


### PR DESCRIPTION
Fixes #84.

This PR renames attributes as follows:

Old | New
----|-----
`selectedLines` | `highlightedLines`
`showLines` | `showLineNumbers`

When rendering the block on the frontend, the old attributes will still work.

However, when opening the post editor the old deprecated attributes will need to be re-populated. I didn't implement migration of these old attributes because (1) only `showLines` is in a current release, (2) there are only 400 active installs of this plugin currently, and (3) I wasn't sure how best to do it on the JS side of things.