### PR TITLE
Rename remaining references of "selected" to "highlighted"

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -447,7 +447,7 @@ function render_block( $attributes, $content ) {
 	$highlighted   = get_transient( $transient_key );
 
 	if ( ! DEVELOPMENT_MODE && $highlighted && isset( $highlighted['content'] ) ) {
-		return $render_output($highlighted['attributes'], $matches['before'], $highlighted['content'], $end_tags);
+		return $render_output( $highlighted['attributes'], $matches['before'], $highlighted['content'], $end_tags );
 	}
 
 	try {
@@ -502,7 +502,7 @@ function render_block( $attributes, $content ) {
 
 		set_transient( $transient_key, compact( 'content', 'attributes' ), MONTH_IN_SECONDS );
 
-		return $render_output($attributes, $matches['before'], $content, $end_tags);
+		return $render_output( $attributes, $matches['before'], $content, $end_tags );
 	} catch ( Exception $e ) {
 		return sprintf(
 			'<!-- %s(%s): %s -->%s',

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -43,7 +43,6 @@ const FRONTEND_STYLE_HANDLE = 'syntax-highlighting-code-block';
  *
  * @param float[] $rgb_array An array representing an RGB color.
  * @param float   $tint      How much of a tint to apply; a number between 0 and 1.
- *
  * @return float[] The new color as an RGB array.
  */
 function add_tint_to_rgb( $rgb_array, $tint ) {
@@ -57,10 +56,9 @@ function add_tint_to_rgb( $rgb_array, $tint ) {
 /**
  * Get the relative luminance of a color.
  *
- * @param float[] $rgb_array An array representing an RGB color.
- *
  * @link https://en.wikipedia.org/wiki/Relative_luminance
  *
+ * @param float[] $rgb_array An array representing an RGB color.
  * @return float A value between 0 and 100 representing the luminance of a color.
  *     The closer to to 100, the higher the luminance is; i.e. the lighter it is.
  */
@@ -74,7 +72,6 @@ function get_relative_luminance( $rgb_array ) {
  * Check whether or not a given RGB array is considered a "dark theme."
  *
  * @param float[] $rgb_array The RGB array to test.
- *
  * @return bool True if the theme's background has a "dark" luminance.
  */
 function is_dark_theme( $rgb_array ) {
@@ -85,7 +82,6 @@ function is_dark_theme( $rgb_array ) {
  * Convert an RGB array to hexadecimal representation.
  *
  * @param float[] $rgb_array The RGB array to convert.
- *
  * @return string A hexadecimal representation.
  */
 function get_hex_from_rgb( $rgb_array ) {
@@ -144,7 +140,6 @@ function get_options() {
  * Get the single, specified plugin option.
  *
  * @param string $option_name The plugin option name.
- *
  * @return mixed
  */
 function get_option( $option_name ) {
@@ -557,7 +552,6 @@ function parse_highlighted_lines( $highlighted_lines ) {
  *
  * @param WP_Error $validity Validator object.
  * @param string   $input    Incoming theme name.
- *
  * @return mixed
  */
 function validate_theme_name( $validity, $input ) {

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -340,12 +340,12 @@ function get_styles( $attributes ) {
 	if ( ! $added_highlighted_color_style && $attributes['highlightedLines'] ) {
 		if ( has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
 			/**
-			 * Filters the background color of a selected line.
+			 * Filters the background color of a highlighted line.
 			 *
 			 * This filter takes precedence over any settings set in the database as an option. Additionally, if this filter
 			 * is provided, then a color selector will not be provided in Customizer.
 			 *
-			 * @param string $rgb_color An RGB hexadecimal (with the #) to be used as the background color of a selected line.
+			 * @param string $rgb_color An RGB hexadecimal (with the #) to be used as the background color of a highlighted line.
 			 *
 			 * @since 1.1.5
 			 */

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -34,7 +34,7 @@ const DEFAULT_THEME = 'default';
 
 const BLOCK_STYLE_FILTER = 'syntax_highlighting_code_block_style';
 
-const HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER = 'syntax_highlighting_code_highlighted_line_background_color';
+const HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER = 'syntax_highlighted_line_background_color';
 
 const FRONTEND_STYLE_HANDLE = 'syntax-highlighting-code-block';
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -341,7 +341,7 @@ function get_styles( $attributes ) {
 		$added_inline_style = true;
 	}
 
-	if ( ! $added_highlighted_color_style && $attributes['highlightedLines'] ) {
+	if ( ! $added_highlighted_color_style && ! empty( $attributes['highlightedLines'] ) ) {
 		if ( has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
 			/**
 			 * Filters the background color of a highlighted line.

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -123,7 +123,7 @@ function get_default_line_background_color( $theme_name ) {
  *
  * @return array
  */
-function get_options() {
+function get_plugin_options() {
 	$options = \get_option( OPTION_NAME, [] );
 
 	$theme_name = isset( $options['theme_name'] ) ? $options['theme_name'] : DEFAULT_THEME;
@@ -142,8 +142,8 @@ function get_options() {
  * @param string $option_name The plugin option name.
  * @return mixed
  */
-function get_option( $option_name ) {
-	return get_options()[ $option_name ];
+function get_plugin_option( $option_name ) {
+	return get_plugin_options()[ $option_name ];
 }
 
 /**
@@ -288,7 +288,7 @@ function register_styles( WP_Styles $styles ) {
 		 */
 		$style = apply_filters( BLOCK_STYLE_FILTER, DEFAULT_THEME );
 	} else {
-		$style = get_option( 'theme_name' );
+		$style = get_plugin_option( 'theme_name' );
 	}
 
 	$default_style_path = sprintf(
@@ -351,7 +351,7 @@ function get_styles( $attributes ) {
 			 */
 			$line_color = apply_filters( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER, get_default_line_background_color( DEFAULT_THEME ) );
 		} else {
-			$line_color = get_option( 'highlighted_line_background_color' );
+			$line_color = get_plugin_option( 'highlighted_line_background_color' );
 		}
 
 		$styles .= "<style>.hljs > mark.shcb-loc { background-color: $line_color; }</style>";
@@ -635,7 +635,7 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register' );
 function override_highlighted_line_background_color_post_value( WP_Customize_Manager $wp_customize ) {
 	$highlighted_line_background_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_background_color]' );
 	if ( $highlighted_line_background_color_setting && ! $highlighted_line_background_color_setting->post_value() ) {
-		$highlighted_line_background_color_setting->default = get_default_line_background_color( get_option( 'theme_name' ) ); // This has no effect.
+		$highlighted_line_background_color_setting->default = get_default_line_background_color( get_plugin_option( 'theme_name' ) ); // This has no effect.
 		$wp_customize->set_post_value( $highlighted_line_background_color_setting->id, $highlighted_line_background_color_setting->default );
 	}
 }

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Syntax-highlighting Code Block (with Server-side Rendering)
  * Plugin URI:   https://github.com/westonruter/syntax-highlighting-code-block
  * Description:  Extending the Code block with syntax highlighting rendered on the server, thus being AMP-compatible and having faster frontend performance.
- * Version:      1.2-beta
+ * Version:      1.2-beta2
  * Author:       Weston Ruter
  * Author URI:   https://weston.ruter.net/
  * License:      GPL2
@@ -22,7 +22,7 @@ use WP_Error;
 use WP_Customize_Manager;
 use WP_Styles;
 
-const PLUGIN_VERSION = '1.2-beta';
+const PLUGIN_VERSION = '1.2-beta2';
 
 const BLOCK_NAME = 'core/code';
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -432,6 +432,10 @@ function render_block( $attributes, $content ) {
 		return preg_replace( '/(<pre[^>]*>)(<code)/', '$1<div>$2', $start_tags, 1 );
 	};
 
+	$render_output = function ( $attributes, $before, $content, $end_tags ) use ( $inject_classes ) {
+		return get_styles( $attributes ) . $inject_classes( $before, $attributes ) . $content . $end_tags;
+	};
+
 	/**
 	 * Filters the list of languages that are used for auto-detection.
 	 *
@@ -443,7 +447,7 @@ function render_block( $attributes, $content ) {
 	$highlighted   = get_transient( $transient_key );
 
 	if ( ! DEVELOPMENT_MODE && $highlighted && isset( $highlighted['content'] ) ) {
-		return get_styles( $attributes ) . $inject_classes( $matches['before'], $highlighted['attributes'] ) . $highlighted['content'] . $end_tags;
+		return $render_output($highlighted['attributes'], $matches['before'], $highlighted['content'], $end_tags);
 	}
 
 	try {
@@ -498,12 +502,7 @@ function render_block( $attributes, $content ) {
 
 		set_transient( $transient_key, compact( 'content', 'attributes' ), MONTH_IN_SECONDS );
 
-		$matches['before'] = $inject_classes(
-			$matches['before'],
-			$attributes
-		);
-
-		return get_styles( $attributes ) . $matches['before'] . $content . $end_tags;
+		return $render_output($attributes, $matches['before'], $content, $end_tags);
 	} catch ( Exception $e ) {
 		return sprintf(
 			'<!-- %s(%s): %s -->%s',

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -34,7 +34,7 @@ const DEFAULT_THEME = 'default';
 
 const BLOCK_STYLE_FILTER = 'syntax_highlighting_code_block_style';
 
-const HIGHLIGHTED_LINE_BG_FILTER = 'syntax_highlighting_code_highlighted_line_bg';
+const HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER = 'syntax_highlighting_code_highlighted_line_background_color';
 
 const FRONTEND_STYLE_HANDLE = 'syntax-highlighting-code-block';
 
@@ -106,10 +106,9 @@ function get_hex_from_rgb( $rgb_array ) {
  * In a light theme, a default light blue is used.
  *
  * @param string $theme_name The theme name to get a color for.
- *
  * @return string A hexadecimal value.
  */
-function get_default_line_bg_color( $theme_name ) {
+function get_default_line_background_color( $theme_name ) {
 	require_highlight_php_functions();
 
 	$theme_rgb = \HighlightUtilities\getThemeBackgroundColor( $theme_name );
@@ -134,8 +133,8 @@ function get_options() {
 	$theme_name = isset( $options['theme_name'] ) ? $options['theme_name'] : DEFAULT_THEME;
 	return array_merge(
 		[
-			'theme_name'                => DEFAULT_THEME,
-			'highlighted_line_bg_color' => get_default_line_bg_color( $theme_name ),
+			'theme_name'                        => DEFAULT_THEME,
+			'highlighted_line_background_color' => get_default_line_background_color( $theme_name ),
 		],
 		$options
 	);
@@ -344,7 +343,7 @@ function get_styles( $attributes ) {
 	}
 
 	if ( ! $added_highlighted_color_style && $attributes['highlightedLines'] ) {
-		if ( has_filter( HIGHLIGHTED_LINE_BG_FILTER ) ) {
+		if ( has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
 			/**
 			 * Filters the background color of a selected line.
 			 *
@@ -355,9 +354,9 @@ function get_styles( $attributes ) {
 			 *
 			 * @since 1.1.5
 			 */
-			$line_color = apply_filters( HIGHLIGHTED_LINE_BG_FILTER, get_default_line_bg_color( DEFAULT_THEME ) );
+			$line_color = apply_filters( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER, get_default_line_background_color( DEFAULT_THEME ) );
 		} else {
-			$line_color = get_option( 'highlighted_line_bg_color' );
+			$line_color = get_option( 'highlighted_line_background_color' );
 		}
 
 		$styles .= "<style>.hljs > mark.shcb-loc { background-color: $line_color; }</style>";
@@ -579,7 +578,7 @@ function validate_theme_name( $validity, $input ) {
  * @param WP_Customize_Manager $wp_customize The Customizer object.
  */
 function customize_register( $wp_customize ) {
-	if ( has_filter( BLOCK_STYLE_FILTER ) && has_filter( HIGHLIGHTED_LINE_BG_FILTER ) ) {
+	if ( has_filter( BLOCK_STYLE_FILTER ) && has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
 		return;
 	}
 
@@ -610,9 +609,9 @@ function customize_register( $wp_customize ) {
 		);
 	}
 
-	if ( ! has_filter( HIGHLIGHTED_LINE_BG_FILTER ) ) {
+	if ( ! has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
 		$wp_customize->add_setting(
-			'syntax_highlighting[highlighted_line_bg_color]',
+			'syntax_highlighting[highlighted_line_background_color]',
 			[
 				'type'              => 'option',
 				'sanitize_callback' => 'sanitize_hex_color',
@@ -621,10 +620,10 @@ function customize_register( $wp_customize ) {
 		$wp_customize->add_control(
 			new \WP_Customize_Color_Control(
 				$wp_customize,
-				'syntax_highlighting[highlighted_line_bg_color]',
+				'syntax_highlighting[highlighted_line_background_color]',
 				[
 					'section'     => 'colors',
-					'settings'    => 'syntax_highlighting[highlighted_line_bg_color]',
+					'settings'    => 'syntax_highlighting[highlighted_line_background_color]',
 					'label'       => __( 'Highlighted Line Color', 'syntax-highlighting-code-block' ),
 					'description' => __( 'The background color of a highlighted line.', 'syntax-highlighting-code-block' ),
 				]
@@ -639,15 +638,15 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register' );
  *
  * This is an unfortunate workaround for the Customizer not respecting dynamic updates to the default setting value.
  *
- * @todo What's missing is dynamically changing the default value of the highlighted_line_bg_color control based on the selected theme.
+ * @todo What's missing is dynamically changing the default value of the highlighted_line_background_color control based on the selected theme.
  *
- * @param \WP_Customize_Manager $wp_customize Customize manager.
+ * @param WP_Customize_Manager $wp_customize Customize manager.
  */
-function override_highlighted_line_bg_color_post_value( \WP_Customize_Manager $wp_customize ) {
-	$highlighted_line_bg_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_bg_color]' );
-	if ( $highlighted_line_bg_color_setting && ! $highlighted_line_bg_color_setting->post_value() ) {
-		$highlighted_line_bg_color_setting->default = get_default_line_bg_color( get_option( 'theme_name' ) ); // This has no effect.
-		$wp_customize->set_post_value( $highlighted_line_bg_color_setting->id, $highlighted_line_bg_color_setting->default );
+function override_highlighted_line_background_color_post_value( WP_Customize_Manager $wp_customize ) {
+	$highlighted_line_background_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_background_color]' );
+	if ( $highlighted_line_background_color_setting && ! $highlighted_line_background_color_setting->post_value() ) {
+		$highlighted_line_background_color_setting->default = get_default_line_background_color( get_option( 'theme_name' ) ); // This has no effect.
+		$wp_customize->set_post_value( $highlighted_line_background_color_setting->id, $highlighted_line_background_color_setting->default );
 	}
 }
-add_action( 'customize_preview_init', __NAMESPACE__ . '\override_highlighted_line_bg_color_post_value' );
+add_action( 'customize_preview_init', __NAMESPACE__ . '\override_highlighted_line_background_color_post_value' );

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -443,7 +443,7 @@ function render_block( $attributes, $content ) {
 	$highlighted   = get_transient( $transient_key );
 
 	if ( ! DEVELOPMENT_MODE && $highlighted && isset( $highlighted['content'] ) ) {
-		return $inject_classes( $matches['before'], $highlighted['attributes'] ) . $highlighted['content'] . $end_tags;
+		return get_styles( $attributes ) . $inject_classes( $matches['before'], $highlighted['attributes'] ) . $highlighted['content'] . $end_tags;
 	}
 
 	try {

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -140,10 +140,14 @@ function get_plugin_options() {
  * Get the single, specified plugin option.
  *
  * @param string $option_name The plugin option name.
- * @return mixed
+ * @return string|null
  */
 function get_plugin_option( $option_name ) {
-	return get_plugin_options()[ $option_name ];
+	$options = get_plugin_options();
+	if ( array_key_exists( $option_name, $options ) ) {
+		return $options[ $option_name ];
+	}
+	return null;
 }
 
 /**

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -405,10 +405,6 @@ function render_block( $attributes, $content ) {
 			$added_classes .= ' shcb-line-numbers';
 		}
 
-		if ( $attributes['highlightedLines'] ) {
-			$added_classes .= ' shcb-selected-lines';
-		}
-
 		if ( $attributes['wrapLines'] ) {
 			$added_classes .= ' shcb-wrap-lines';
 		}


### PR DESCRIPTION
This PR amends #92 to further fix #84.

Also:

* Use `background` instead of `bg`.
* Disambiguate `get_option()` function from core by renaming to `get_plugin_option()`. Also prevent non-existent option from causing PHP error. 
* Reduce `syntax_highlighting_code_selected_line_bg` filter to `syntax_highlighted_line_background_color`.
* Remove unused `shcb-selected-lines` class name.
* Fix insertion of styles when not in development mode.