### PR TITLE
Add support for Gutenberg block alignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import {
 	PanelBody,
 	PanelRow,
 } from '@wordpress/components';
-import { Fragment, createRef, useEffect, useState } from '@wordpress/element';
+import { Fragment, useRef, useEffect, useState } from '@wordpress/element';
 import * as BlockEditor from '@wordpress/block-editor';
 
 /**
@@ -46,7 +46,7 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 
 	const HighlightablePlainText = (props_) => {
 		const { highlightedLines, ...props } = props_;
-		const plainTextRef = createRef();
+		const plainTextRef = useRef();
 		const [styles, setStyles] = useState({});
 
 		useEffect(() => {


### PR DESCRIPTION
The `HighlightablePlainText` component was accidentally creating a new ref each time by calling `createRef`. We should have been using `useRef`, which will always return the same ref for us to use on each re-render. Since changing alignment Gutenberg causes a new instance of the component to mount, we shouldn't be creating a new reference each time.

Also added support for using block alignment.

Fixes #128

/cc @grgarside