### PR TITLE
Introduce filter which disables frontend styling

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -686,7 +686,7 @@ function customize_register( $wp_customize ) {
 				'type'        => 'select',
 				'section'     => 'colors',
 				'label'       => __( 'Syntax Highlighting Theme', 'syntax-highlighting-code-block' ),
-				'description' => __( 'Preview the theme by navigating to a page with a code block to see the different themes in action.', 'syntax-highlighting-code-block' ),
+				'description' => __( 'Preview the theme by navigating to a page with a Code block to see the different themes in action.', 'syntax-highlighting-code-block' ),
 				'choices'     => $choices,
 			]
 		);
@@ -708,13 +708,13 @@ function customize_register( $wp_customize ) {
 					'section'     => 'colors',
 					'settings'    => 'syntax_highlighting[highlighted_line_background_color]',
 					'label'       => __( 'Highlighted Line Color', 'syntax-highlighting-code-block' ),
-					'description' => __( 'The background color of a highlighted line.', 'syntax-highlighting-code-block' ),
+					'description' => __( 'The background color of a highlighted line in a Code block.', 'syntax-highlighting-code-block' ),
 				]
 			)
 		);
 	}
 }
-add_action( 'customize_register', __NAMESPACE__ . '\customize_register' );
+add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
 
 /**
  * Override the post value for the highlighted line background color when the theme has been highlighted.

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -332,6 +332,20 @@ function register_styles( WP_Styles $styles ) {
 }
 
 /**
+ * Determines whether styling is enabled.
+ *
+ * @return bool Styling.
+ */
+function is_styling_enabled() {
+	/**
+	 * Filters whether the Syntax-highlighting Code Block's default styling is enabled.
+	 *
+	 * @param bool $enabled Default styling enabled.
+	 */
+	return (bool) apply_filters( 'syntax_highlighting_code_block_styling', true );
+}
+
+/**
  * Get styles.
  *
  * @param array $attributes Attributes.
@@ -339,6 +353,10 @@ function register_styles( WP_Styles $styles ) {
  */
 function get_styles( $attributes ) {
 	if ( is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		return '';
+	}
+
+	if ( ! is_styling_enabled() ) {
 		return '';
 	}
 
@@ -640,6 +658,10 @@ function validate_theme_name( $validity, $input ) {
  */
 function customize_register( $wp_customize ) {
 	if ( has_filter( BLOCK_STYLE_FILTER ) && has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
+		return;
+	}
+
+	if ( ! is_styling_enabled() ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #194.

Given this `post_content`:

```html
<!-- wp:code {"highlightedLines":"2"} -->
<pre class="wp-block-code"><code>if ( a &lt; b ) {
   alert( 'A is less than B!' );
}</code></pre>
<!-- /wp:code -->
```

This renders as a Code block that looks like this:

> ![image](https://user-images.githubusercontent.com/134745/97395480-4cf7aa00-18a2-11eb-8429-32c56e0665b5.png)

If then this new PHP filter is added:

```php
add_filter( 'syntax_highlighting_code_block_styling', '__return_false' );
```

Any styling is omitted from being added to the frontend:

> ![image](https://user-images.githubusercontent.com/134745/97395570-79132b00-18a2-11eb-9f4e-e270bbd8e223.png)

It's then up to the developer to add the required styling.

This will also prevent adding the Customizer controls for styling, while also moving them to the bottom when they are enabled.

Before | After | Styles Turned Off
-------|------|------------------
![image](https://user-images.githubusercontent.com/134745/97396505-76b1d080-18a4-11eb-9b54-f79cadb75fea.png) | ![image](https://user-images.githubusercontent.com/134745/97396478-67328780-18a4-11eb-960e-f998404daae4.png) | ![image](https://user-images.githubusercontent.com/134745/97396541-88937380-18a4-11eb-93b0-f338f1c5d627.png)
