### PR TITLE
Fix font-size handling and line wrapping in latest Gutenberg

### DIFF
--- a/editor-styles.css
+++ b/editor-styles.css
@@ -22,6 +22,17 @@ textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
 	white-space: pre-wrap !important;
 }
 
+/* Gutenberg 9.2+ uses a contenteditable div */
+.shcb-plain-text.rich-text {
+	white-space: pre !important;
+	overflow-x: auto !important;
+}
+
+.shcb-plain-text.rich-text.shcb-plain-text-wrap-lines {
+	white-space: pre-wrap !important;
+	overflow: auto !important;
+}
+
 .code-block-overlay {
 	height: 100%;
 	left: 0;

--- a/editor-styles.css
+++ b/editor-styles.css
@@ -1,36 +1,35 @@
-.shcb-plain-text.shcb-plain-text-wrap-lines {
+.shcb-textedit.shcb-textedit-wrap-lines {
 	overflow: auto !important;
 }
 
 /* Gutenberg 7.9+ uses a `<code>` element */
-code.shcb-plain-text {
+code.shcb-textedit {
 	white-space: pre !important;
 	overflow-x: auto !important;
 }
 
-code.shcb-plain-text.shcb-plain-text-wrap-lines {
+code.shcb-textedit.shcb-textedit-wrap-lines {
 	white-space: pre-wrap !important;
 }
 
 /* Gutenberg 7.8 and below uses a `<textarea>` element */
-textarea.shcb-plain-text {
+textarea.shcb-textedit {
 	white-space: pre !important;
 	overflow-x: auto !important;
 }
 
-textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
+textarea.shcb-textedit.shcb-textedit-wrap-lines {
 	white-space: pre-wrap !important;
 }
 
 /* Gutenberg 9.2+ uses a contenteditable div */
-.shcb-plain-text.rich-text {
+.shcb-textedit.rich-text {
 	white-space: pre !important;
 	overflow-x: auto !important;
 }
 
-.shcb-plain-text.rich-text.shcb-plain-text-wrap-lines {
+.shcb-textedit.rich-text.shcb-textedit-wrap-lines {
 	white-space: pre-wrap !important;
-	overflow: auto !important;
 }
 
 .code-block-overlay {
@@ -45,7 +44,7 @@ textarea.shcb-plain-text.shcb-plain-text-wrap-lines {
 	z-index: 10;
 }
 
-.shcb-plain-text-wrap-lines + .code-block-overlay {
+.shcb-textedit-wrap-lines + .code-block-overlay {
 	white-space: pre-wrap;
 }
 

--- a/editor-styles.css
+++ b/editor-styles.css
@@ -2,16 +2,6 @@
 	overflow: auto !important;
 }
 
-/* Gutenberg 7.9+ uses a `<code>` element */
-code.shcb-textedit {
-	white-space: pre !important;
-	overflow-x: auto !important;
-}
-
-code.shcb-textedit.shcb-textedit-wrap-lines {
-	white-space: pre-wrap !important;
-}
-
 /* Gutenberg 7.8 and below uses a `<textarea>` element */
 textarea.shcb-textedit {
 	white-space: pre !important;
@@ -19,6 +9,16 @@ textarea.shcb-textedit {
 }
 
 textarea.shcb-textedit.shcb-textedit-wrap-lines {
+	white-space: pre-wrap !important;
+}
+
+/* Gutenberg 7.9+ uses a `<code>` element */
+code.shcb-textedit {
+	white-space: pre !important;
+	overflow-x: auto !important;
+}
+
+code.shcb-textedit.shcb-textedit-wrap-lines {
 	white-space: pre-wrap !important;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Extending the Code block with syntax highlighting rendered on the server, thus b
 
 **Contributors:** [westonruter](https://profiles.wordpress.org/westonruter), [allejo](https://profiles.wordpress.org/allejo)  
 **Tags:** [block](https://wordpress.org/plugins/tags/block), [code](https://wordpress.org/plugins/tags/code), [code syntax](https://wordpress.org/plugins/tags/code-syntax), [syntax highlight](https://wordpress.org/plugins/tags/syntax-highlight), [code highlighting](https://wordpress.org/plugins/tags/code-highlighting)  
-**Requires at least:** 5.2  
-**Tested up to:** 5.5  
+**Requires at least:** 5.5  
+**Tested up to:** 5.6  
 **Stable tag:** 1.2.3  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.6  

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Syntax-highlighting Code Block (with Server-side Rendering) ===
 Contributors: westonruter, allejo
 Tags: block, code, code syntax, syntax highlight, code highlighting
-Requires at least: 5.2
-Tested up to: 5.5
+Requires at least: 5.5
+Tested up to: 5.6
 Stable tag: 1.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/index.js
+++ b/src/index.js
@@ -204,8 +204,8 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 				placeholder: __('Write code…'),
 				'aria-label': __('Code'),
 				className: [
-					'shcb-plain-text',
-					attributes.wrapLines ? 'shcb-plain-text-wrap-lines' : '',
+					'shcb-textedit',
+					attributes.wrapLines ? 'shcb-textedit-wrap-lines' : '',
 				].join(' '),
 			};
 

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,18 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 							cName += ' highlighted';
 						}
 
+						if (useBlockProps) {
+							return (
+								<span
+									key={i}
+									className={cName}
+									dangerouslySetInnerHTML={{
+										__html: v || ' ',
+									}}
+								/>
+							);
+						}
+
 						return (
 							<span key={i} className={cName}>
 								{v || ' '}

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 					resize: computedStyles.getPropertyValue('resize'),
 				});
 			}
-		}, []);
+		}, [props.style]);
 
 		const TextArea = useBlockProps ? RichText : PlainText;
 
@@ -265,9 +265,14 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 					</InspectorControls>
 					{(() => {
 						if (useBlockProps) {
+							const blockProps = useBlockProps();
+
+							// Copy the styles to ensure that the code-block-overlay is updated when the font size is changed in Gutenberg 9.5+.
+							textAreaProps.style = blockProps.style;
+
 							// Must be kept in sync with Gutenberg 9.2+: <https://github.com/WordPress/gutenberg/blob/v9.2.0/packages/block-library/src/code/edit.js>.
 							return (
-								<pre {...useBlockProps()}>
+								<pre {...blockProps}>
 									<HighlightableTextArea {...textAreaProps} />
 								</pre>
 							);


### PR DESCRIPTION
Fixes #228
Fixes #229

* Changing the font-size in Gutenberg 9.5 will now ensure that any highlighted lines will maintain their position.
* When in Gutenberg 9.2+, the lines of text are now added to the overlay without escaping since a `RichText` component is used instead of `PlainText`. Line wrapping (or no-wrapping) is also now applies as expected. This was missed in a previous PR.

👎  Before, upon changing the font size to small or large:

![image](https://user-images.githubusercontent.com/134745/100968866-00c60800-34e7-11eb-89bc-92969a17e9c4.png) 
![image](https://user-images.githubusercontent.com/134745/100968919-1a674f80-34e7-11eb-8792-02a067f42e8c.png)

👍  After:

![image](https://user-images.githubusercontent.com/134745/100969002-3d91ff00-34e7-11eb-8a58-8b63ad1f854f.png)
![image](https://user-images.githubusercontent.com/134745/100969023-471b6700-34e7-11eb-8ffc-cfaf8e599e5b.png)
