### PR TITLE
Fix ability to paste HTML markup into Code blocks (without it being converted to rich text)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 
 		if (useBlockProps) {
 			props.preserveWhiteSpace = true;
+			props.__unstablePastePlainText = true; // See https://github.com/WordPress/gutenberg/pull/27236
 		}
 
 		return (


### PR DESCRIPTION
As reported in a [support topic](https://wordpress.org/support/topic/two-bugs-in-v1-3/):

> **Can’t paste XML or HTML into the Code block when this plugin is activated. It basically pastes in a blank line.**
>
> Note: If you change the block to “Edit as HTML” and try pasting into that, you end up with the “Invalid block” error. So your only option is to manually type in the code.

The reason for the bug is that our RichText support was added (in https://github.com/westonruter/syntax-highlighting-code-block/pull/200) _before_ this issue was reported upstream in https://github.com/WordPress/gutenberg/issues/26689 and fixed by introducing the `__unstablePastePlainText` prop in https://github.com/WordPress/gutenberg/pull/27236

The fix appears to just be to add the `__unstablePastePlainText` prop as the Core code block [now has](https://github.com/WordPress/gutenberg/blob/bb9ec5ef29287467a823790d19b18244910cd347/packages/block-library/src/code/edit.js#L19).

Before:

https://user-images.githubusercontent.com/134745/102702272-ea71b900-4215-11eb-9cd5-773f8a36f2a9.mov

After:

https://user-images.githubusercontent.com/134745/102702277-f3628a80-4215-11eb-93a4-bb613e80a4c4.mov