### PR TITLE
Fix color for lines on first render in Customizer and dynamically update default color when theme is changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3176,30 +3176,10 @@
             "regenerator-runtime": "^0.13.4"
           }
         },
-        "@wordpress/i18n": {
-          "version": "3.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
-          "integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.19",
-            "memize": "^1.1.0",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.2.0"
-          }
-        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-          "dev": true
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@wordpress/api-fetch": "^3.21.0",
     "@wordpress/components": "^12.0.0",
     "@wordpress/editor": "^9.25.0",
     "@wordpress/element": "^2.19.0",
@@ -53,7 +54,7 @@
     "lint:php": "vendor/bin/phpcs",
     "lint:js": "wp-scripts lint-js",
     "lint:pkg-json": "wp-scripts lint-pkg-json . --ignorePath .gitignore",
-    "start": "wp-scripts start"
+    "start": "wp-scripts start src/index.js src/customize-controls.js --output-path=build"
   },
   "npmpackagejsonlint": {
     "extends": "@wordpress/npm-package-json-lint-config",

--- a/src/customize-controls.js
+++ b/src/customize-controls.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * External dependencies
+ */
+import { memoize } from 'lodash';
+
+const { customize } = global.wp;
+
+const themeNameCustomizeId = 'syntax_highlighting[theme_name]';
+const lineColorCustomizeId =
+	'syntax_highlighting[highlighted_line_background_color]';
+
+/**
+ * Init.
+ *
+ * @param {Object} args
+ * @param {wp.customize.Control} args.themeNameControl
+ * @param {wp.customize.Control} args.lineColorControl
+ */
+function init({ themeNameControl, lineColorControl }) {
+	const colorPickerElement = lineColorControl.container.find(
+		'.color-picker-hex'
+	);
+
+	themeNameControl.setting.bind(async (newThemeName) => {
+		const isColorCustomized =
+			lineColorControl.setting().toLowerCase() !==
+			lineColorControl.params.defaultValue.toLowerCase();
+
+		lineColorControl.params.defaultValue = await getDefaultThemeLineColor(
+			newThemeName
+		);
+
+		// Make sure the default value gets propagated into the wpColorPicker.
+		colorPickerElement.wpColorPicker(
+			'defaultColor',
+			lineColorControl.params.defaultValue
+		);
+
+		// Update the color to be the default if it was not customized.
+		if (!isColorCustomized) {
+			lineColorControl.setting.set(lineColorControl.params.defaultValue);
+		}
+	});
+}
+
+/**
+ * Get default theme line color.
+ *
+ * @param {string} themeName
+ * @return {Promise} Promise.
+ */
+const getDefaultThemeLineColor = memoize((themeName) => {
+	return apiFetch({
+		path: `/syntax-highlighting-code-block/v1/highlighted-line-background-color/${themeName}`,
+	});
+});
+
+// Initialize once the controls are available.
+customize.control(
+	themeNameCustomizeId,
+	lineColorCustomizeId,
+	(themeNameControl, lineColorControl) => {
+		init({
+			themeNameControl,
+			lineColorControl,
+		});
+	}
+);

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -709,7 +709,7 @@ function customize_register( $wp_customize ) {
 			'syntax_highlighting[highlighted_line_background_color]',
 			[
 				'type'              => 'option',
-				'default'           => DEFAULT_HIGHLIGHTED_COLOR,
+				'default'           => get_default_line_background_color( get_theme_name() ),
 				'sanitize_callback' => 'sanitize_hex_color',
 			]
 		);
@@ -741,8 +741,8 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
 function override_highlighted_line_background_color_post_value( WP_Customize_Manager $wp_customize ) {
 	$highlighted_line_background_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_background_color]' );
 	if ( $highlighted_line_background_color_setting && ! $highlighted_line_background_color_setting->post_value() ) {
-		// This is the default value used when highlighting lines on first load in Customizer.
-		$highlighted_line_background_color_setting->default = get_plugin_option( 'highlighted_line_background_color' );
+		// Make sure the default highlighted line color reflects the currently-selected theme.
+		$highlighted_line_background_color_setting->default = get_default_line_background_color( get_theme_name() );
 		$wp_customize->set_post_value( $highlighted_line_background_color_setting->id, $highlighted_line_background_color_setting->default );
 	}
 }

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -32,6 +32,8 @@ const OPTION_NAME = 'syntax_highlighting';
 
 const DEFAULT_THEME = 'default';
 
+const DEFAULT_HIGHLIGHTED_COLOR = '#ddf6ff';
+
 const BLOCK_STYLE_FILTER = 'syntax_highlighting_code_block_style';
 
 const HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER = 'syntax_highlighted_line_background_color';
@@ -115,7 +117,7 @@ function get_default_line_background_color( $theme_name ) {
 		);
 	}
 
-	return '#ddf6ff';
+	return DEFAULT_HIGHLIGHTED_COLOR;
 }
 
 /**
@@ -697,6 +699,7 @@ function customize_register( $wp_customize ) {
 			'syntax_highlighting[highlighted_line_background_color]',
 			[
 				'type'              => 'option',
+				'default'           => DEFAULT_HIGHLIGHTED_COLOR,
 				'sanitize_callback' => 'sanitize_hex_color',
 			]
 		);
@@ -728,7 +731,8 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
 function override_highlighted_line_background_color_post_value( WP_Customize_Manager $wp_customize ) {
 	$highlighted_line_background_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_background_color]' );
 	if ( $highlighted_line_background_color_setting && ! $highlighted_line_background_color_setting->post_value() ) {
-		$highlighted_line_background_color_setting->default = get_default_line_background_color( get_plugin_option( 'theme_name' ) ); // This has no effect.
+		// This is the default value used when highlighting lines on first load in Customizer
+		$highlighted_line_background_color_setting->default = get_plugin_option( 'highlighted_line_background_color' );
 		$wp_customize->set_post_value( $highlighted_line_background_color_setting->id, $highlighted_line_background_color_setting->default );
 	}
 }

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -751,7 +751,7 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
  * Enqueue scripts for Customizer.
  */
 function enqueue_customize_scripts() {
-	$script_handle = 'syntax-highlighting-code-block-scripts';
+	$script_handle = 'syntax-highlighting-code-block-customize-controls';
 	$script_path   = '/build/customize-controls.js';
 	$script_asset  = require __DIR__ . '/build/customize-controls.asset.php';
 	$in_footer     = true;

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -25,6 +25,10 @@ use WP_REST_Server;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Customize_Color_Control;
+use Highlight\Highlighter;
+use function HighlightUtilities\splitCodeIntoArray;
+use function HighlightUtilities\getAvailableStyleSheets;
+use function HighlightUtilities\getThemeBackgroundColor;
 
 const PLUGIN_VERSION = '1.3.1-beta';
 
@@ -115,7 +119,7 @@ function get_hex_from_rgb( $rgb_array ) {
 function get_default_line_background_color( $theme_name ) {
 	require_highlight_php_functions();
 
-	$theme_rgb = \HighlightUtilities\getThemeBackgroundColor( $theme_name );
+	$theme_rgb = getThemeBackgroundColor( $theme_name );
 
 	if ( is_dark_theme( $theme_rgb ) ) {
 		return get_hex_from_rgb(
@@ -562,7 +566,7 @@ function render_block( $attributes, $content ) {
 			spl_autoload_register( 'Highlight\Autoloader::load' );
 		}
 
-		$highlighter = new \Highlight\Highlighter();
+		$highlighter = new Highlighter();
 		if ( ! empty( $auto_detect_languages ) ) {
 			$highlighter->setAutodetectLanguages( $auto_detect_languages );
 		}
@@ -591,7 +595,7 @@ function render_block( $attributes, $content ) {
 			require_highlight_php_functions();
 
 			$highlighted_lines = parse_highlighted_lines( $attributes['highlightedLines'] );
-			$lines             = \HighlightUtilities\splitCodeIntoArray( $content );
+			$lines             = splitCodeIntoArray( $content );
 			$content           = '';
 
 			// We need to wrap the line of code twice in order to let out `white-space: pre` CSS setting to be respected
@@ -660,7 +664,7 @@ function parse_highlighted_lines( $highlighted_lines ) {
 function validate_theme_name( $validity, $input ) {
 	require_highlight_php_functions();
 
-	$themes = \HighlightUtilities\getAvailableStyleSheets();
+	$themes = getAvailableStyleSheets();
 
 	if ( ! in_array( $input, $themes, true ) ) {
 		$validity->add( 'invalid_theme', __( 'Unrecognized theme', 'syntax-highlighting-code-block' ) );
@@ -688,7 +692,7 @@ function customize_register( $wp_customize ) {
 	$theme_name = get_theme_name();
 
 	if ( ! has_filter( BLOCK_STYLE_FILTER ) ) {
-		$themes = \HighlightUtilities\getAvailableStyleSheets();
+		$themes = getAvailableStyleSheets();
 		sort( $themes );
 		$choices = array_combine( $themes, $themes );
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -295,13 +295,11 @@ function enqueue_editor_assets() {
 }
 
 /**
- * Register assets for the frontend.
+ * Get highlight theme name.
  *
- * Asset(s) will only be enqueued if needed.
- *
- * @param WP_Styles $styles Styles.
+ * @return string Theme name.
  */
-function register_styles( WP_Styles $styles ) {
+function get_theme_name() {
 	if ( has_filter( BLOCK_STYLE_FILTER ) ) {
 		/**
 		 * Filters the style used for the code syntax block.
@@ -319,6 +317,18 @@ function register_styles( WP_Styles $styles ) {
 	} else {
 		$style = get_plugin_option( 'theme_name' );
 	}
+	return $style;
+}
+
+/**
+ * Register assets for the frontend.
+ *
+ * Asset(s) will only be enqueued if needed.
+ *
+ * @param WP_Styles $styles Styles.
+ */
+function register_styles( WP_Styles $styles ) {
+	$style = get_theme_name();
 
 	$default_style_path = sprintf(
 		'vendor/scrivo/%s/styles/%s.css',

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -731,7 +731,7 @@ add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
 function override_highlighted_line_background_color_post_value( WP_Customize_Manager $wp_customize ) {
 	$highlighted_line_background_color_setting = $wp_customize->get_setting( 'syntax_highlighting[highlighted_line_background_color]' );
 	if ( $highlighted_line_background_color_setting && ! $highlighted_line_background_color_setting->post_value() ) {
-		// This is the default value used when highlighting lines on first load in Customizer
+		// This is the default value used when highlighting lines on first load in Customizer.
 		$highlighted_line_background_color_setting->default = get_plugin_option( 'highlighted_line_background_color' );
 		$wp_customize->set_post_value( $highlighted_line_background_color_setting->id, $highlighted_line_background_color_setting->default );
 	}


### PR DESCRIPTION
The "Highlighted Line Color" is correctly selected in the Customize panel but the color used in the preview at first load is incorrect.

**Before**

![image](https://user-images.githubusercontent.com/1246453/103183011-b6754400-4864-11eb-948f-17877430ba91.png)

**After**

![image](https://user-images.githubusercontent.com/1246453/103183022-c8ef7d80-4864-11eb-94f5-9bcd38259e15.png)