### PR TITLE
Hide overflow on code-block-overlay to prevent doubled scrollbars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 				setStyles({
 					fontFamily: computedStyles.getPropertyValue('font-family'),
 					fontSize: computedStyles.getPropertyValue('font-size'),
-					overflow: computedStyles.getPropertyValue('overflow'),
+					overflow: 'hidden', // Prevent doubled-scrollbars from appearing.
 					overflowWrap: computedStyles.getPropertyValue(
 						'overflow-wrap'
 					),


### PR DESCRIPTION
Fixes #297.

This prevents a scrollbar from appearing for the code overlay:

Before | After
--------|-----
![image](https://user-images.githubusercontent.com/134745/111005938-ae478380-8340-11eb-8e0e-f5b514aef1dc.png) | ![image](https://user-images.githubusercontent.com/134745/111005905-97089600-8340-11eb-8783-9760fdd856ac.png)

There doesn't appear to be a need to ever show the overflow for the overlay since it is not scrolled:

https://user-images.githubusercontent.com/134745/111006132-0f6f5700-8341-11eb-87d2-6e29f65fca13.mov