### PR TITLE
Preserve styled markup in Code 

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -622,9 +622,47 @@ function render_block( $attributes, $content ) {
 
 		$language = $attributes['language'];
 
+		$content = $matches['content'];
+		// @todo We need to remove all tags but remember the byte positions, and also we need to do the same for entities.
+
+		$token_offets = [];
+
+		$token_regexps = [
+			'(?P<start_tag><\w[^<]*?>)',
+			'(?P<end_tag><\\/\w[^<]*?>)',
+			'(?P<entity>&(?:\w+|#(?:\d+|x[0-9a-fA-F]+));)',
+			//'(?P<named_entity>&\w+;)',
+			//'(?P<decimal_entity>&#\d+;)',
+			//'(?P<hex_entity>&#x[0-9a-fA-F]+;)',
+		];
+
+		$offset_diff = 0;
+
+		$pattern = '/' . implode( '|', $token_regexps ) . '/s';
+
+		$content = preg_replace_callback(
+			$pattern,
+			static function ( $matches ) use ( $token_offets, $offset_diff ) {
+				$original = $matches[0][0];
+
+				if ( $matches['start_tag'][1] !== -1 ) {
+					$replacement = '';
+				} elseif ( $matches['end_tag'][1] !== -1 ) {
+					$replacement = '';
+				} elseif ( $matches['entity'][1] !== -1 ) {
+					$replacement = html_entity_decode( $matches['entity'][0], ENT_QUOTES | ENT_HTML5, 'utf-8' );
+				}
+
+				return $replacement;
+			},
+			$content,
+			-1,
+			$count,
+			PREG_OFFSET_CAPTURE
+		);
+
 		// Note that the decoding here is reversed later in the escape() function.
 		// @todo Now that Code blocks may have markup (e.g. bolding, italics, and hyperlinks), these need to be removed and then restored after highlighting is completed.
-		$content = html_entity_decode( $matches['content'], ENT_QUOTES );
 
 		// Convert from Prism.js languages names.
 		if ( 'clike' === $language ) {
@@ -661,6 +699,8 @@ function render_block( $attributes, $content ) {
 		if ( ! DEVELOPMENT_MODE ) {
 			set_transient( $transient_key, compact( 'content', 'attributes' ), MONTH_IN_SECONDS );
 		}
+
+		// @todo The tags and entities extracted from $content need to be restored now.
 
 		return inject_markup( $matches['pre_start_tag'], $matches['code_start_tag'], $attributes, $content );
 	} catch ( Exception $e ) {


### PR DESCRIPTION
Fixes #205

As it stands right Current Code block I'm testing with:

```html
<!-- wp:code {"highlightedLines":"4-18","showLineNumbers":true} -->
<pre class="wp-block-code"><code>&lt;br&gt;
&amp;amp;
&lt;script&gt;
if ( true &amp;&amp; "foo" &lt;= 'bar' &amp;&amp; 'baz' &gt;= "quux" ) 
{} else if ( 
  "<strong>bolded</strong>" &amp;&amp; 
  "<em>italicized</em>" &amp;&amp; 
  "<a href="https://example.com/">linked</a>" &amp;&amp; 
  "<strong><em><a href="https://example.com">all</a></em></strong>" ) 
{} else if ( 
  "bolded spanning <strong>tokens" == 123</strong> 
) {} else if ( 
  "italicized spanning <em>tokens" == null</em> 
) {} else if ( 
  "link spanning <a href="https://example.com">tokens" == true</a> 
) {} else {
  // &#91;gallery]
}
&lt;/script&gt;
&#91;test]
&#91;embed]https://twitter.com/WordPress/status/1631756836666785795&#91;/embed]

https:&#47;&#47;twitter.com/WordPress/status/1631756836666785795

&#91;sic]</code></pre>
<!-- /wp:code -->
```

It's currently rendered as:

Without plugin | Editor        | Frontend
---------------|---------------|-------------
![image](https://user-images.githubusercontent.com/134745/223585566-b4d78303-50e5-4427-b053-0c403b9c01dd.png) | ![image](https://user-images.githubusercontent.com/134745/223585634-ebdaacf0-ddae-4990-a3a3-64cd21e623cc.png) | ![image](https://user-images.githubusercontent.com/134745/223585710-b48b59be-e7b5-4919-bdb6-0f16689036f5.png)

Notice that the shortcodes are no longer being rendered, which is a fix. But what is still broken is the handling of stylized text inside the Code block. It is is getting corrupted by highlight.php.

This PR seeks to address this by adding the formatting back in after the code has been highlighted.