### PR TITLE
Prevent highlighted lines in editor from overflowing container

### DIFF
--- a/editor-styles.css
+++ b/editor-styles.css
@@ -2,27 +2,6 @@
 	overflow: auto !important;
 }
 
-/* Gutenberg 7.8 and below uses a `<textarea>` element */
-textarea.shcb-textedit {
-	white-space: pre !important;
-	overflow-x: auto !important;
-}
-
-textarea.shcb-textedit.shcb-textedit-wrap-lines {
-	white-space: pre-wrap !important;
-}
-
-/* Gutenberg 7.9+ uses a `<code>` element */
-code.shcb-textedit {
-	white-space: pre !important;
-	overflow-x: auto !important;
-}
-
-code.shcb-textedit.shcb-textedit-wrap-lines {
-	white-space: pre-wrap !important;
-}
-
-/* Gutenberg 9.2+ uses a contenteditable div */
 .shcb-textedit.rich-text {
 	white-space: pre !important;
 	overflow-x: auto !important;

--- a/editor-styles.css
+++ b/editor-styles.css
@@ -12,9 +12,10 @@
 }
 
 .code-block-overlay {
+	box-sizing: border-box;
 	height: 100%;
 	left: 0;
-	padding: inherit;
+	padding: inherit; /* To match the padding in the parent since this is positioned absolutely */
 	pointer-events: none;
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
In Twenty Twenty-One:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/224170766-5d218185-68a8-4fda-84fb-b7b52699cbb6.png) | ![image](https://user-images.githubusercontent.com/134745/224170803-b647d919-0c1e-44ce-9f95-ecf33a884aa3.png)

Removes obsolete CSS for old versions of Gutenberg which should have been removed in #688.