### PR TITLE
fix stylesheet name issue

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -851,7 +851,7 @@ function customize_register( WP_Customize_Manager $wp_customize ): void {
 		);
 	}
 
-	if ( ! has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) ) {
+	if ( ! has_filter( HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER ) && $theme_name ) {
 		$default_color = strtolower( get_default_line_background_color( $theme_name ) );
 		$wp_customize->add_setting(
 			'syntax_highlighting[highlighted_line_background_color]',

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -308,7 +308,7 @@ function register_editor_assets( WP_Block_Type $block ): void {
 /**
  * Get highlight theme name.
  *
- * @return string Theme name.
+ * @return string|null Theme name or null if disabled.
  */
 function get_theme_name(): string {
 	if ( has_filter( BLOCK_STYLE_FILTER ) ) {
@@ -331,7 +331,7 @@ function get_theme_name(): string {
 	} else {
 		$style = get_plugin_options()['theme_name'];
 	}
-	return $style;
+	return is_string( $style ) ? $style : null;
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -308,7 +308,7 @@ function register_editor_assets( WP_Block_Type $block ): void {
 /**
  * Get highlight theme name.
  *
- * @return string|null Theme name or null if disabled.
+ * @return string Theme name or empty string if disabled.
  */
 function get_theme_name(): string {
 	if ( has_filter( BLOCK_STYLE_FILTER ) ) {
@@ -331,7 +331,7 @@ function get_theme_name(): string {
 	} else {
 		$style = get_plugin_options()['theme_name'];
 	}
-	return is_string( $style ) ? $style : null;
+	return is_string( $style ) ? $style : '';
 }
 
 /**


### PR DESCRIPTION
Hotfix for critical error in customize api.
`Fatal error: Uncaught DomainException: There is no stylesheet by the name of '' in /app/wp-content/plugins/syntax-highlighting-code-block/vendor/scrivo/highlight-php/HighlightUtilities/_themeColors.php:475 Stack trace: #0 /app/wp-content/plugins/syntax-highlighting-code-block/vendor/scrivo/highlight-php/HighlightUtilities/functions.php(91): _getThemeBackgroundColor(false) #1 /app/wp-content/plugins/syntax-highlighting-code-block/syntax-highlighting-code-block.php(127): HighlightUtilities\getThemeBackgroundColor(false) #2 /app/wp-content/plugins/syntax-highlighting-code-block/syntax-highlighting-code-block.php(776): Syntax_Highlighting_Code_Block\get_default_line_background_color(false) #3 /app/wp-includes/class-wp-hook.php(308): Syntax_Highlighting_Code_Block\customize_register(Object(WP_Customize_Manager)) #4 /app/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array) #5 /app/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #6 /app/wp-includes/class-wp-customize-manager.php(934): do_action('customize_regis...', Object(WP_Customize_Manager)) #7 /app/wp-includes/class-wp-hook.php(308): WP_Customize_Manager->wp_loaded('') #8 /app/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array) #9 /app/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #10 /app/wp-settings.php(645): do_action('wp_loaded') #11 /app/wp-config.php(121): require_once('/app/wp-setting...') #12 /app/wp-load.php(50): require_once('/app/wp-config....') #13 /app/wp-admin/admin.php(34): require_once('/app/wp-load.ph...') #14 /app/wp-admin/customize.php(13): require_once('/app/wp-admin/a...') #15 {main} thrown in /app/wp-content/plugins/syntax-highlighting-code-block/vendor/scrivo/highlight-php/HighlightUtilities/_themeColors.php on line 475 `
Tested environments:

    WordPress 6.2.2
    PHP 8.1

