### PR TITLE
Add Developer Actions and Filters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,7 @@ module.exports = function (grunt) {
 				'readme.txt',
 				'LICENSE',
 				'build/*',
+				'inc/*',
 			];
 
 			grunt.config.set('copy', {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -466,7 +466,16 @@ function get_styles( array $attributes ): string {
  * @return array<string, string> Mapping slug to name.
  */
 function get_language_names(): array {
-	return require PLUGIN_DIR . '/language-names.php';
+	$language_names = require PLUGIN_DIR . '/language-names.php';
+
+	/**
+	 * Filters the list of language names.
+	 *
+	 * @param array<string, string> $language_names Mapping slug to name.
+	 *
+	 * @since 1.4.1
+	 */
+	return apply_filters( 'syntax_highlighting_code_block_language_names', $language_names );
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -557,6 +557,18 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 			),
 			$pre_start_tag
 		);
+
+		/**
+		 * Filter the start tag.
+		 *
+		 * @param string $pre_start_tag  The `<pre>` start tag.
+		 * @param string $element_id    The ID of the element containing the language info.
+		 * @param string $language_name The name of the language.
+		 * @param string $language_slug The slug of the language.
+		 *
+		 * @since 1.4.1
+		 */
+		$pre_start_tag = apply_filters( 'syntax_highlighting_code_block_pre_start_tag', $pre_start_tag, $element_id, $language_name, $attributes['language'] );
 	}
 	$end_tags .= '</pre>';
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -716,14 +716,11 @@ function render_block( array $attributes, string $content ): string {
 	/**
 	 * Action for when the block is being rendered.
 	 *
-	 * @param null|array $highlighted {
-	 *    Previously highlighted content.
-	 *
-	 *    @type string $content The block's highlighted/parsed content.
-	 *    @type array  $attributes Block attributes. See constant ATTRIBUTE_SCHEMA.
-	 * }
+	 * @param null|array $highlighted
+	 * @param array      $attributes Block attributes. See constant ATTRIBUTE_SCHEMA.
+	 * @param string     $content    Block's original content.
 	 */
-	do_action( 'syntax_highlighting_code_block_render', $highlighted, $attributes, $content, $highlighted );
+	do_action( 'syntax_highlighting_code_block_render', $highlighted, $attributes, $content );
 
 	if (
 		is_array( $highlighted )

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -593,19 +593,6 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 			),
 			$pre_start_tag
 		);
-
-		/**
-		 * Filter the start tag. Allow others to insert markup.
-		 *
-		 * @param string $pre_start_tag  The `<pre>` start tag.
-		 * @param string $element_id    The ID of the element containing the language info.
-		 * @param string $language_name The name of the language.
-		 * @param string $language_slug The slug of the language.
-		 * @param array  $attributes    Block attributes.
-		 *
-		 * @since 1.4.1
-		 */
-		$pre_start_tag = apply_filters( 'syntax_highlighting_code_block_pre_start_tag', $pre_start_tag, $element_id, $language_name, $attributes['language'], $attributes );
 	}
 	$end_tags .= '</pre>';
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -493,28 +493,38 @@ function get_language_names(): array {
  * @return string Injected markup.
  */
 function inject_markup( string $pre_start_tag, string $code_start_tag, array $attributes, string $content ): string {
-	$added_classes = 'hljs';
+	$added_classes = array( 'hljs' );
 
 	if ( $attributes['language'] ) {
-		$added_classes .= " language-{$attributes['language']}";
+		$added_classes[] = " language-{$attributes['language']}";
 	}
 
 	if ( $attributes['showLineNumbers'] || $attributes['highlightedLines'] ) {
-		$added_classes .= ' shcb-code-table';
+		$added_classes[] = 'shcb-code-table';
 	}
 
 	if ( $attributes['showLineNumbers'] ) {
-		$added_classes .= ' shcb-line-numbers';
+		$added_classes[] = 'shcb-line-numbers';
 	}
 
 	if ( $attributes['wrapLines'] ) {
-		$added_classes .= ' shcb-wrap-lines';
+		$added_classes[] = 'shcb-wrap-lines';
 	}
+
+	/**
+	 * Filters the classes added to the `<code>` element.
+	 *
+	 * @param array $added_classes Index array of CSS classes to add.
+	 * @param array $attributes    Block attributes.
+	 *
+	 * @since 1.4.1
+	 */
+	$added_classes = apply_filters( 'syntax_highlighting_code_block_code_classes', $added_classes, $attributes );
 
 	// @todo Update this to use WP_HTML_Tag_Processor.
 	$code_start_tag = (string) preg_replace(
 		'/(<code[^>]*\sclass=")/',
-		'$1' . esc_attr( $added_classes ) . ' ',
+		'$1' . esc_attr( implode( ' ', $added_classes ) ) . ' ',
 		$code_start_tag,
 		1,
 		$count
@@ -522,7 +532,7 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 	if ( 0 === $count ) {
 		$code_start_tag = (string) preg_replace(
 			'/(?<=<code\b)/',
-			sprintf( ' class="%s"', esc_attr( $added_classes ) ),
+			sprintf( ' class="%s"', esc_attr( implode( ' ', $added_classes ) ) ),
 			$code_start_tag,
 			1
 		);
@@ -559,7 +569,7 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 		);
 
 		/**
-		 * Filter the start tag.
+		 * Filter the start tag. Allow others to insert markup.
 		 *
 		 * @param string $pre_start_tag  The `<pre>` start tag.
 		 * @param string $element_id    The ID of the element containing the language info.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -33,6 +33,13 @@ function boot(): void {
 	add_action( 'init', __NAMESPACE__ . '\init', 100 );
 	add_action( 'customize_register', __NAMESPACE__ . '\customize_register', 100 );
 	add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_endpoint' );
+
+	/**
+	 * Action fired after the plugin has been bootstrapped.
+	 *
+	 * @since 1.4.1
+	 */
+	do_action( 'syntax_highlighting_code_block_boot' );
 }
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -37,6 +37,10 @@ function boot(): void {
 	/**
 	 * Action fired after the plugin has been bootstrapped.
 	 *
+	 * This action is fired immediately after the `plugins_loaded` action is completed.
+	 * Use this action to hook in early knowing the plugin's actions and filters have
+	 * been registered.
+	 *
 	 * @since 1.4.1
 	 */
 	do_action( 'syntax_highlighting_code_block_boot' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -556,14 +556,40 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 			esc_html( $attributes['language'] )
 		);
 
-		// Also include the language in data attributes on the root <pre> element for maximum styling flexibility.
+		/**
+		 * Add the language info to markup with ARIA attributes. Filterable.
+		 */
+		$tag_attributes = array(
+			'aria-describedby'        => $element_id,
+			'data-shcb-language-name' => $language_name,
+			'data-shcb-language-slug' => $attributes['language'],
+		);
+
+		/**
+		 * Filter the attributes added to the `<pre>` element.
+		 *
+		 * @param array $tag_attributes Associative array of attributes.
+		 * @param array $attributes     Block attributes.
+		 *
+		 * @since 1.4.1
+		 */
+		$tag_attributes = apply_filters( 'syntax_highlighting_code_block_start_tag_attributes', $tag_attributes, $attributes );
+
+		// Format the attributes for the start tag and build start tag.
 		$pre_start_tag = str_replace(
 			'>',
 			sprintf(
-				' aria-describedby="%s" data-shcb-language-name="%s" data-shcb-language-slug="%s">',
-				esc_attr( $element_id ),
-				esc_attr( $language_name ),
-				esc_attr( $attributes['language'] )
+				' %s>',
+				implode(
+					' ',
+					array_map(
+						function ( $key, $value ) {
+							return sprintf( '%s="%s"', sanitize_title( $key ), esc_attr( $value ) );
+						},
+						array_keys( $tag_attributes ),
+						$tag_attributes
+					)
+				)
 			),
 			$pre_start_tag
 		);
@@ -575,10 +601,11 @@ function inject_markup( string $pre_start_tag, string $code_start_tag, array $at
 		 * @param string $element_id    The ID of the element containing the language info.
 		 * @param string $language_name The name of the language.
 		 * @param string $language_slug The slug of the language.
+		 * @param array  $attributes    Block attributes.
 		 *
 		 * @since 1.4.1
 		 */
-		$pre_start_tag = apply_filters( 'syntax_highlighting_code_block_pre_start_tag', $pre_start_tag, $element_id, $language_name, $attributes['language'] );
+		$pre_start_tag = apply_filters( 'syntax_highlighting_code_block_pre_start_tag', $pre_start_tag, $element_id, $language_name, $attributes['language'], $attributes );
 	}
 	$end_tags .= '</pre>';
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -675,7 +675,6 @@ function render_block( array $attributes, string $content ): string {
 	 * @since 1.4.1
 	 */
 	$transient_key = apply_filters( 'syntax_highlighting_code_block_transient_key', $transient_key, $attributes );
-
 	$highlighted   = $transient_key ? get_transient( $transient_key ) : null;
 
 	/**
@@ -690,8 +689,6 @@ function render_block( array $attributes, string $content ): string {
 	 */
 	do_action( 'syntax_highlighting_code_block_render', $highlighted, $attributes, $content, $highlighted );
 
-		
-	
 	if (
 		is_array( $highlighted )
 		&&

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -716,6 +716,15 @@ function render_block( array $attributes, string $content ): string {
 			$highlighter->setAutodetectLanguages( $auto_detect_languages );
 		}
 
+		/**
+		 * Fires after the highlighter is initialized.
+		 *
+		 * @param \Highlight\Highlighter   $highlighter Highlighter.
+		 * @param array                    $attributes  Block attributes. See constant ATTRIBUTE_SCHEMA.
+		 * @param string                   $content     Block's original content.
+		 */
+		do_action( 'syntax_highlighting_code_block_highlighter_init', $highlighter, $attributes, $content );
+
 		$language = $attributes['language'];
 
 		// Note that the decoding here is reversed later in the escape() function.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -656,6 +656,18 @@ function render_block( array $attributes, string $content ): string {
 
 	// Use the previously-highlighted content if cached.
 	$transient_key = ! DEVELOPMENT_MODE ? get_transient_key( $matches['content'], $attributes, is_feed(), $auto_detect_languages ) : null;
+
+	/**
+	 * Filters the transient key used to cache the highlighted content.
+	 *
+	 * @param string|null $transient_key Transient key.
+	 * @param array       $attributes    Block attributes. See constant ATTRIBUTE_SCHEMA.
+	 *
+	 * @since 1.4.1
+	 */
+	$transient_key = apply_filters( 'syntax_highlighting_code_block_transient_key', $transient_key, $attributes );
+
+		
 	$highlighted   = $transient_key ? get_transient( $transient_key ) : null;
 	if (
 		is_array( $highlighted )
@@ -672,7 +684,21 @@ function render_block( array $attributes, string $content ): string {
 		&&
 		isset( $highlighted['attributes']['wrapLines'] ) && is_bool( $highlighted['attributes']['wrapLines'] )
 	) {
-		return inject_markup( $matches['pre_start_tag'], $matches['code_start_tag'], $highlighted['attributes'], $highlighted['content'] );
+		// Get injected markup, set up for filter.
+		$injected_markup = inject_markup( $matches['pre_start_tag'], $matches['code_start_tag'], $highlighted['attributes'], $highlighted['content'] );
+
+		/**
+		 * Filter the injected markup before it's returned.
+		 *
+		 * @param string $injected_markup Injected markup.
+		 * @param array  $attributes      Block attributes. See constant ATTRIBUTE_SCHEMA.
+		 * @param string $content         Block's original content.
+		 *
+		 * @since 1.4.1
+		 */
+		$injected_markup = apply_filters( 'syntax_highlighting_code_block_injected_markup', $injected_markup, $attributes, $content );
+
+		return $injected_markup;
 	}
 
 	try {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -731,6 +731,8 @@ function render_block( array $attributes, string $content ): string {
 		 * @param \Highlight\Highlighter   $highlighter Highlighter.
 		 * @param array                    $attributes  Block attributes. See constant ATTRIBUTE_SCHEMA.
 		 * @param string                   $content     Block's original content.
+		 *
+		 * @since 1.4.1
 		 */
 		do_action( 'syntax_highlighting_code_block_highlighter_init', $highlighter, $attributes, $content );
 
@@ -776,7 +778,17 @@ function render_block( array $attributes, string $content ): string {
 			set_transient( $transient_key, compact( 'content', 'attributes' ), MONTH_IN_SECONDS );
 		}
 
-		return inject_markup( $matches['pre_start_tag'], $matches['code_start_tag'], $attributes, $content );
+		// Retrieve injected markup.
+		$injected_markup = inject_markup( $matches['pre_start_tag'], $matches['code_start_tag'], $attributes, $content );
+
+		/**
+		 * Filter the injected markup before it's returned.
+		 *
+		 * @see filter definition above.
+		 *
+		 * @since 1.4.1
+		 */
+		return apply_filters( 'syntax_highlighting_code_block_injected_markup', $injected_markup, $attributes, $content );
 	} catch ( Exception $e ) {
 		return sprintf(
 			'<!-- %s(%s): %s -->%s',

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,9 @@
 /**
  * WordPress dependencies
  */
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, createHooks, applyFilters } from '@wordpress/hooks';
+
+const codeBlockHooks = createHooks();
 
 /**
  * Internal dependencies
@@ -21,6 +23,11 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 		return settings;
 	}
 
+	const mergedAttributes = {
+		...settings.attributes,
+		...syntaxHighlightingCodeBlockType.attributes, // @todo Why can't this be supplied via a blocks.getBlockAttributes filter?
+	};
+
 	return {
 		...settings,
 
@@ -29,10 +36,20 @@ const extendCodeBlockWithSyntaxHighlighting = (settings) => {
 		 * There seems to be a race condition, as wp.blocks.getBlockType('core/code') returns the PHP-augmented data after the
 		 * page loads, but at the moment this filter calls it is still undefined.
 		 */
-		attributes: {
-			...settings.attributes,
-			...syntaxHighlightingCodeBlockType.attributes, // @todo Why can't this be supplied via a blocks.getBlockAttributes filter?
-		},
+		/**
+		 * Filter for block attributes. Useful for setting custom defaults.
+		 *
+		 * @since 1.4.1
+		 *
+		 * @param {Object} attributes Block attributes.
+		 * @return {Object} Modified attributes.
+		 */
+		attributes: applyFilters(
+			'syntaxHighlightingCodeBlockAttributes',
+			mergedAttributes,
+			settings.attributes,
+			syntaxHighlightingCodeBlockType.attributes, // @todo Why can't this be supplied via a blocks.getBlockAttributes filter?
+		),
 
 		edit,
 

--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Syntax-highlighting Code Block (with Server-side Rendering)
  * Plugin URI:   https://github.com/westonruter/syntax-highlighting-code-block
  * Description:  Extending the Code block with syntax highlighting rendered on the server, thus being AMP-compatible and having faster frontend performance.
- * Version:      1.4.0
+ * Version:      1.4.1
  * Author:       Weston Ruter
  * Author URI:   https://weston.ruter.net/
  * License:      GPL2
@@ -16,7 +16,7 @@
 
 namespace Syntax_Highlighting_Code_Block;
 
-const PLUGIN_VERSION = '1.4.0';
+const PLUGIN_VERSION = '1.4.1';
 
 const PLUGIN_MAIN_FILE = __FILE__;
 


### PR DESCRIPTION
This PR seeks to add several actions and filters that'll help others extend the block.

Resolves #488 #191

## Background

I'd like to add a few addons for this plugin:

1. Copy code functionality
2. Code captions

I need several filters/actions to do this, hence this PR. I've put together a proof-of-concept of the first addon, which adds a copy button to the code block.

I've done my best to only insert actions/filters where needed. To see examples of some of these in use, please check out my addon code for this plugin: https://github.com/DLXPlugins/syntax-highlighting-code-block-copy-addon/blob/main/syntax-highlighting-code-block-copy-addon.php

## Proof of Concept

![dlx-000054](https://github.com/westonruter/syntax-highlighting-code-block/assets/636521/30c555fc-6490-436e-b992-2a42896d2ce1)

Please see repo release with attached ZIP files: https://github.com/DLXPlugins/syntax-highlighting-code-block-copy-addon/releases/tag/1.0.0

Thank you for considering this PR.
