### PR TITLE
Opt to register styles in standard way

### DIFF
--- a/syntax-highlighting-code-block.php
+++ b/syntax-highlighting-code-block.php
@@ -36,7 +36,11 @@ const BLOCK_STYLE_FILTER = 'syntax_highlighting_code_block_style';
 
 const HIGHLIGHTED_LINE_BACKGROUND_COLOR_FILTER = 'syntax_highlighted_line_background_color';
 
-const FRONTEND_STYLE_HANDLE = 'syntax-highlighting-code-block';
+const THEME_STYLE_HANDLE = 'syntax-highlighting-code-block-theme';
+
+const BLOCK_STYLE_HANDLE = 'syntax-highlighting-code-block';
+
+const STYLE_HANDLES = [ THEME_STYLE_HANDLE, BLOCK_STYLE_HANDLE ];
 
 const REST_API_NAMESPACE = 'syntax-highlighting-code-block/v1';
 


### PR DESCRIPTION
Fixes #286.

By registering styles for the block in the traditional way, we can be guaranteed that the style will be printed to the page. There are scenarios (see #286) in which a block can be rendered and yet not printed, and this can prevent the inlined styles from being served. Styles were originally inlined in this way in order to prevent serving them when they weren't needed. Nevertheless, block themes now by default only print styles for blocks which are actually rendered on the page. And yet, classic themes do still print all styles for all registered blocks in the `head` unconditionally. In order to retain that conditional style printing, you can add the following plugin code:

```php
add_filter( 'should_load_separate_core_block_assets', '__return_true' );
```

For classic themes, this has the effect of printing block styles in the footer since only at this point does WordPress know which blocks have been rendered. The downside here is that there may be a flash of unstyled content and critical styles may not be loaded soon enough.