### PR TITLE
Automate checking for upstream changes to Code block's edit.js

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Validate package.json
         run: npm run lint:pkg-json
 
+      - name: Check @wordpress/block-library checksum
+        run: npm run md5sum:check
+
       - name: Detect coding standard violations (stylelint)
         run: npm run lint:css
 

--- a/block-library.md5
+++ b/block-library.md5
@@ -1,0 +1,1 @@
+8d5405f9c190cb3c26853a4954685925  node_modules/@wordpress/block-library/src/code/edit.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "devDependencies": {
         "@wordpress/api-fetch": "6.43.0",
         "@wordpress/block-editor": "12.14.0",
+        "@wordpress/block-library": "8.23.0",
         "@wordpress/blocks": "12.23.0",
         "@wordpress/components": "25.12.0",
         "@wordpress/editor": "13.23.0",
@@ -4107,6 +4108,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@preact/signals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.1.tgz",
+      "integrity": "sha512-hRPvp1C2ooDzOHqfnhdpHgoIFDbYFAXLhoid3+jSItuPPD/J0r/UsiWKv/8ZO/oEhjRaP0M5niuRYsWqmY2GEA==",
+      "dev": true,
+      "dependencies": {
+        "@preact/signals-core": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.5.0.tgz",
+      "integrity": "sha512-U2diO1Z4i1n2IoFgMYmRdHWGObNrcuTRxyNEn7deSq2cru0vj0583HYQZHsAqcs7FE+hQyX3mjIV7LAfHCvy8w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
@@ -6704,6 +6731,74 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/block-library": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-8.23.0.tgz",
+      "integrity": "sha512-ysdybvb8vMYvhD0KK8lZMeE3jaxhegJaVeoOjBafFBBtK69PPK9C3Rbn/LSipICMIJC8AjPkZ7sveauW64G4+Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.46.0",
+        "@wordpress/api-fetch": "^6.43.0",
+        "@wordpress/autop": "^3.46.0",
+        "@wordpress/blob": "^3.46.0",
+        "@wordpress/block-editor": "^12.14.0",
+        "@wordpress/blocks": "^12.23.0",
+        "@wordpress/components": "^25.12.0",
+        "@wordpress/compose": "^6.23.0",
+        "@wordpress/core-data": "^6.23.0",
+        "@wordpress/data": "^9.16.0",
+        "@wordpress/date": "^4.46.0",
+        "@wordpress/deprecated": "^3.46.0",
+        "@wordpress/dom": "^3.46.0",
+        "@wordpress/element": "^5.23.0",
+        "@wordpress/escape-html": "^2.46.0",
+        "@wordpress/hooks": "^3.46.0",
+        "@wordpress/html-entities": "^3.46.0",
+        "@wordpress/i18n": "^4.46.0",
+        "@wordpress/icons": "^9.37.0",
+        "@wordpress/interactivity": "^2.7.0",
+        "@wordpress/keycodes": "^3.46.0",
+        "@wordpress/notices": "^4.14.0",
+        "@wordpress/primitives": "^3.44.0",
+        "@wordpress/private-apis": "^0.28.0",
+        "@wordpress/reusable-blocks": "^4.23.0",
+        "@wordpress/rich-text": "^6.23.0",
+        "@wordpress/server-side-render": "^4.23.0",
+        "@wordpress/url": "^3.47.0",
+        "@wordpress/viewport": "^5.23.0",
+        "@wordpress/wordcount": "^3.46.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "escape-html": "^1.0.3",
+        "fast-average-color": "^9.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/block-serialization-default-parser": {
       "version": "4.46.0",
       "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.46.0.tgz",
@@ -7635,6 +7730,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/interactivity": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-2.7.0.tgz",
+      "integrity": "sha512-qAUC8EwtQqSbmQHtodUZ9L83o6YBYHJOlAQcbce5DeWVqyez/jQyLtff4s6QMh0HEluHlhBZV7TddiuOgVkdFA==",
+      "dev": true,
+      "dependencies": {
+        "@preact/signals": "^1.1.3",
+        "deepsignal": "^1.3.6",
+        "preact": "^10.13.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/is-shallow-equal": {
       "version": "4.46.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.46.0.tgz",
@@ -8264,6 +8373,24 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/viewport": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-5.23.0.tgz",
+      "integrity": "sha512-5nB5dqTnbPuqp6HYfVGGlCLfWbvdpMl2NFsWgHCqcQrKQcRcNMRd24bqBIFYY/LRKAJ+EWOzFfSZIqQ0Bu0ifg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.23.0",
+        "@wordpress/data": "^9.16.0",
+        "@wordpress/element": "^5.23.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/warning": {
@@ -12021,6 +12148,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deepsignal": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.3.6.tgz",
+      "integrity": "sha512-yjd+vtiznL6YaMptOsKnEKkPr60OEApa+LRe+Qe6Ile/RfCOrELKk/YM3qVpXFZiyOI3Ng67GDEyjAlqVc697g==",
+      "dev": true,
+      "peerDependencies": {
+        "@preact/signals": "^1.1.4",
+        "@preact/signals-core": "^1.3.1",
+        "@preact/signals-react": "^1.3.3",
+        "preact": "^10.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@preact/signals": {
+          "optional": true
+        },
+        "@preact/signals-core": {
+          "optional": true
+        },
+        "@preact/signals-react": {
+          "optional": true
+        },
+        "preact": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/default-browser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
@@ -14539,6 +14692,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/fast-average-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.4.0.tgz",
+      "integrity": "sha512-bvM8vV6YwK07dPbzFz77zJaBcfF6ABVfgNwaxVgXc2G+o0e/tzLCF9WU8Ryp1r0Nkk6JuJNsWCzbb4cLOMlB+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -24604,6 +24766,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/preact": {
+      "version": "10.19.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.2.tgz",
+      "integrity": "sha512-UA9DX/OJwv6YwP9Vn7Ti/vF80XL+YA5H2l7BpCtUr3ya8LWHFzpiO5R+N7dN16ujpIxhekRFuOOF82bXX7K/lg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@wordpress/api-fetch": "6.43.0",
     "@wordpress/block-editor": "12.14.0",
+    "@wordpress/block-library": "8.23.0",
     "@wordpress/blocks": "12.23.0",
     "@wordpress/components": "25.12.0",
     "@wordpress/editor": "13.23.0",
@@ -64,6 +65,8 @@
     "lint:php:fix": "composer phpcbf",
     "lint:phpstan": "composer analyze",
     "lint:pkg-json": "wp-scripts lint-pkg-json . --ignorePath .gitignore",
+    "md5sum:check": "md5sum -c block-library.md5",
+    "md5sum:update": "md5sum node_modules/@wordpress/block-library/src/code/edit.js > block-library.md5",
     "prepare": "husky install",
     "start": "wp-scripts start src/index.js src/customize-controls.js --output-path=build",
     "symlink-wp-env-install-paths": "bin/symlink-wp-env-install-paths.sh",


### PR DESCRIPTION
Fixes #697.

This will ensure that things like #786 don't fall under the radar. Whenever Dependabot updates the `@wordpress/block-library` package, this will check whether the MD5 hash of the Code block's `edit.js` has been changed. If so, the workflow will fail. After inspecting the file for changes to see if anything needs to be modified in our version, the checksum file can be updated via `npm run md5sum:update` and the file `block-library.md5` committed.