### PR TITLE
Fix compatibility with Gutenberg 17.1 after it removed preserveWhiteSpace serialisation differences

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,5 +3,8 @@
   "plugins": [
     ".",
     "https://downloads.wordpress.org/plugin/gutenberg.zip"
-  ]
+  ],
+  "config": {
+    "WP_DEBUG_LOG": true
+  }
 }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
   "core": null,
-  "plugins": [ "." ]
+  "plugins": [
+    ".",
+    "https://downloads.wordpress.org/plugin/gutenberg.zip"
+  ]
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -635,9 +635,12 @@ function render_block( array $attributes, string $content ): string {
 
 		$language = $attributes['language'];
 
+		// As of Gutenberg 17.1, line breaks in Code blocks are serialized as <br> tags whereas previously they were newlines.
+		$content = str_replace( '<br>', "\n", $matches['content'] );
+
 		// Note that the decoding here is reversed later in the escape() function.
 		// @todo Now that Code blocks may have markup (e.g. bolding, italics, and hyperlinks), these need to be removed and then restored after highlighting is completed.
-		$content = html_entity_decode( $matches['content'], ENT_QUOTES );
+		$content = html_entity_decode( $content, ENT_QUOTES );
 
 		// Convert from Prism.js languages names.
 		if ( 'clike' === $language ) {


### PR DESCRIPTION
Fixes #790.

In Gutenberg 17.1, I paste the following into a new Code block:

```html
<!DOCTYPE html>
<html>
    <head>
        <title>PHP Test</title>
    </head>
    <body>
        <?php echo '<p>Hello World</p>'; ?>
    </body>
</html>
```

When I look at the `post_content`, it shows the block markup as follows:

```html
<!-- wp:code {"language":"xml"} -->
<pre class="wp-block-code"><code>&lt;!DOCTYPE html><br>&lt;html><br>    &lt;head><br>        &lt;title>PHP Test&lt;/title><br>    &lt;/head><br>    &lt;body><br>        &lt;?php echo '&lt;p>Hello World&lt;/p>'; ?><br>    &lt;/body><br>&lt;/html></code></pre>
<!-- /wp:code -->
```

This gets rendered as:

![image](https://github.com/westonruter/syntax-highlighting-code-block/assets/134745/72824ae6-ecbf-4f0d-b2ac-e7f087719bb5)

When this is what is expected:

![image](https://github.com/westonruter/syntax-highlighting-code-block/assets/134745/8334c5fc-6e31-468b-88ab-bc9b68464cb9)

This PR fixes the problem by ensuring `BR` tags are replaced with newlines before applying syntax highlighting.