### PR TITLE
Add AGENTS.md and .gemini/styleguide.md

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc.js
+.gemini
 .github
 .gitignore
 .husky
@@ -11,6 +12,7 @@
 .prettierrc
 .wordpress-org
 .wp-env.json
+AGENTS.md
 Gruntfile.js
 README.md
 bin

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,69 @@
+# WordPress Plugin Style Guide
+
+This style guide outlines the coding conventions for WordPress plugin code. In general, the [coding standards for WordPress](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) should be followed:
+
+* [CSS Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/)
+* [HTML Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/html/)
+* [JavaScript Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/)
+* [PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
+
+Note that for the JavaScript Coding Standards, the code should also be formatted using Prettier, specifically the [wp-prettier](https://www.npmjs.com/package/wp-prettier) fork with the `--paren-spacing` option which inserts many extra spaces inside parentheses.
+
+For the HTML Coding Standards, disregard the guidance that void/empty tags should be self-closing, such as `IMG`, `BR`, `LINK`, or `META`. This is only relevant for XML (XHTML), not HTML. So instead of `<br />` this should only use `<br>`, for example.
+
+Additionally, the [inline documentation standards for WordPress](https://developer.wordpress.org/coding-standards/inline-documentation-standards/) should be followed:
+
+* [PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)
+* [JavaScript Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/)
+
+## Indentation
+
+In general, indentation should use tabs. Refer to `.editorconfig` in the project root for specifics.
+
+## Inline Documentation
+
+It is expected for code introduced in pull requests to have `@since` tags with the `n.e.x.t` placeholder version. It will get replaced with the actual version at the time of release. Do not add any code review comments such code.
+
+Every file, function, class, method constant, and global variable must have an associated docblock with a `@since` tag.
+
+## PHP
+
+Whenever possible, the most specific PHP type hints should be used, when compatible with the minimum version of PHP supported by WordPress, unless the `testVersion` config in `phpcs.xml.dist` is higher.
+
+When native PHP type cannot be used, PHPStan's [PHPDoc Types](https://phpstan.org/writing-php-code/phpdoc-types) should be used, including not only the basic types but also subtypes like `non-empty-string`, [integer ranges](https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges), [general arrays](https://phpstan.org/writing-php-code/phpdoc-types#general-arrays), and especially [array shapes](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes). The types should comply with PHPStan's level 10. 
+
+The one exception for using PHP types is whenever a function is used as a filter. Since plugins can supply any value at all when filtering, it is important for the filtered value to always be `mixed`. The first statement in the function in this case must always check the type, and if it is not the expected type, override it to be so. For example:
+
+```php
+/**
+ * Filters foo.
+ *
+ * @param string|mixed $foo Foo.
+ * @return string Foo.
+ */
+function filter_foo( $foo, int $post_id ): string {
+	if ( ! is_string( $foo ) ) {
+		$foo = '';
+	}
+	/**
+	 * Because plugins do bad things.
+	 *
+	 * @var string $foo
+	 */
+
+	 // Filtering logic goes here.
+
+	 return $foo;
+}
+add_filter( 'foo', 'filter_foo', 10, 2 );
+```
+
+All PHP files should have a namespace which coincides with the `@package` tag in the file's PHPDoc header.
+
+## JavaScript
+
+All JavaScript code should be written with JSDoc comments. All function parameters, return values, and other types should use [TypeScript in JSDoc](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).
+
+JavaScript code is written using ES modules. This JS code must be runnable as-is without having to go through a build step, so it must be plain JavaScript and not TypeScript. The project _may_ also distribute minified versions of these JS files.
+
+Never render HTML `script` markup directly. Always use the relevant APIs in WordPress for adding scripts, including `wp_enqueue_script()`, `wp_add_inline_script()`, `wp_localize_script()`, `wp_print_script_tag()`, `wp_print_inline_script_tag()`, `wp_enqueue_script_module()` among others. Since script modules are used, new scripts should normally have a `type="module"` when printing via `wp_print_inline_script_tag()` and when an external script is used, then `wp_enqueue_script_module()` is preferred.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,18 +60,11 @@ npm run start
 
 ### 4. Building for Production
 
-To create a production build of the JavaScript and other assets, run:
+To create a production build of all assets and a distributable `.zip` file of the plugin, run:
 
 ```bash
 npm run build
 ```
-
-To create a full distributable version of the plugin, including a `.zip` file ready for installation, run:
-
-```bash
-npm run build:dist
-```
-This will create a `syntax-highlighting-code-block.zip` file.
 
 ## Development Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# Agents
+
+## Project Overview
+
+This project is a WordPress plugin that extends the core `core/code` block to add server-side syntax highlighting. It uses the `scrivo/highlight.php` library (a PHP port of `highlight.js`) to render the highlighted code on the server.
+
+This approach has several key benefits:
+- **Performance:** It avoids the need to load a heavy JavaScript syntax highlighting library on the frontend, which improves page load times.
+- **No FOUC:** It prevents a "flash of un-highlighted code" because the code is already highlighted when the page is served.
+- **Compatibility:** It works in environments where JavaScript may be disabled, and is fully compatible with AMP (Accelerated Mobile Pages).
+
+The plugin's administrative interface is built with JavaScript (React) as a standard Gutenberg block modification. It filters the existing `core/code` block to add a custom settings panel in the editor's sidebar, allowing users to select the language, specify lines to highlight, and toggle line numbers and wrapping.
+
+**Key Technologies:**
+- **PHP:** For server-side logic, including the actual syntax highlighting and integration with WordPress.
+- **JavaScript (React/Gutenberg):** For enhancing the block editor interface.
+- **@wordpress/scripts:** Used as the primary tool for building, linting, and running the development environment.
+- **@wordpress/env:** Used for creating a local WordPress development environment.
+- **Composer:** For managing PHP dependencies.
+- **NPM:** For managing JavaScript dependencies and running scripts.
+
+Please also see the [style guide](./.gemini/styleguide.md).
+
+## Building and Running
+
+### 1. Installation
+
+First, install the necessary PHP and JavaScript dependencies.
+
+```bash
+composer install
+npm install
+```
+
+### 2. Running the Local Development Environment
+
+This project uses `@wordpress/env` to create a local WordPress instance for development.
+
+- **Start the environment:**
+  ```bash
+  npm run wp-env start
+  ```
+- **Stop the environment:**
+  ```bash
+  npm run wp-env stop
+  ```
+
+Once started, the local site will be available at `http://localhost:8888`.
+- **WordPress Admin:** `http://localhost:8888/wp-admin`
+- **Username:** `admin`
+- **Password:** `password`
+
+### 3. Development
+
+To watch for changes in the JavaScript files (`src/*.js`) and automatically re-compile them during development, run the following command:
+
+```bash
+npm run start
+```
+
+### 4. Building for Production
+
+To create a production build of the JavaScript and other assets, run:
+
+```bash
+npm run build
+```
+
+To create a full distributable version of the plugin, including a `.zip` file ready for installation, run:
+
+```bash
+npm run build:dist
+```
+This will create a `syntax-highlighting-code-block.zip` file.
+
+## Development Conventions
+
+The project adheres to the official WordPress coding standards for both PHP and JavaScript.
+
+### PHP
+
+- **Standard:** WordPress Coding Standards (`WordPress-Core`, `WordPress-Extra`).
+- **Linter:** `phpcs` (PHP_CodeSniffer)
+- **Static Analysis:** `phpstan`
+- **Commands:**
+	- **Check for issues:** `npm run lint:php` or `composer phpcs`
+	- **Automatically fix issues:** `npm run lint:php:fix` or `composer phpcbf`
+	- **Run static analysis:** `npm run lint:phpstan` or `composer analyze`
+
+### JavaScript
+
+- **Standard:** `@wordpress/eslint-plugin/recommended`.
+- **Linter:** ESLint
+- **Commands:**
+	- **Check for issues:** `npm run lint:js`
+	- **Automatically fix issues:** `npm run lint:js:fix`
+
+All linting tasks can be run at once with `npm run lint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,9 @@ The project adheres to the official WordPress coding standards for both PHP and 
 - **Linter:** `phpcs` (PHP_CodeSniffer)
 - **Static Analysis:** `phpstan`
 - **Commands:**
-	- **Check for issues:** `npm run lint:php` or `composer phpcs`
-	- **Automatically fix issues:** `npm run lint:php:fix` or `composer phpcbf`
-	- **Run static analysis:** `npm run lint:phpstan` or `composer analyze`
+  - **Check for issues:** `npm run lint:php` or `composer phpcs`
+  - **Automatically fix issues:** `npm run lint:php:fix` or `composer phpcbf`
+  - **Run static analysis:** `npm run lint:phpstan` or `composer analyze`
 
 ### JavaScript
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,6 @@ The plugin's administrative interface is built with JavaScript (React) as a stan
 - **Composer:** For managing PHP dependencies.
 - **NPM:** For managing JavaScript dependencies and running scripts.
 
-Please also see the [style guide](./.gemini/styleguide.md).
-
 ## Building and Running
 
 ### 1. Installation
@@ -68,7 +66,7 @@ npm run build
 
 ## Development Conventions
 
-The project adheres to the official WordPress coding standards for both PHP and JavaScript.
+The project adheres to the official WordPress coding standards for both PHP and JavaScript. Please also see the [style guide](./.gemini/styleguide.md).
 
 ### PHP
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ The project adheres to the official WordPress coding standards for both PHP and 
 - **Standard:** `@wordpress/eslint-plugin/recommended`.
 - **Linter:** ESLint
 - **Commands:**
-	- **Check for issues:** `npm run lint:js`
-	- **Automatically fix issues:** `npm run lint:js:fix`
+  - **Check for issues:** `npm run lint:js`
+  - **Automatically fix issues:** `npm run lint:js:fix`
 
 All linting tasks can be run at once with `npm run lint`.


### PR DESCRIPTION
The `AGENTS.md` was initialized with `/init` in Gemini CLI.

The `.gemini/styleguide.md` was copied from https://github.com/westonruter/wp-plugin-template/blob/0959d4d9c0e8c4632836ea3174e31881f6c4b336/.gemini/styleguide.md